### PR TITLE
add abstraction over keybinds for easier control

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,7 @@
     "copy": "cp -r dist/* ../DogfightServer/DogfightServer/wwwroot/",
     "lint": "./node_modules/.bin/eslint . --report-unused-disable-directives --max-warnings 0",
     "format": "./node_modules/.bin/prettier --write 'src/**/*.{ts,tsx,js,jsx}'",
+    "typecheck": "tsc --noEmit",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/client/src/client/keyboard.ts
+++ b/client/src/client/keyboard.ts
@@ -1,18 +1,7 @@
 import { PlayerKeyboard } from "dogfight-types/PlayerKeyboard";
-
-const keyMap: Record<string, keyof PlayerKeyboard> = {
-    ArrowLeft: "left",
-    ArrowRight: "right",
-    ArrowDown: "down",
-    ArrowUp: "up",
-    " ": "space",
-    Enter: "enter",
-    Shift: "shift",
-    Control: "ctrl",
-};
+import { GameAction } from "../hooks/keybinds/models";
 
 type keyboardChangeCallback = (keyboard: PlayerKeyboard) => void;
-
 export class GameKeyboard {
     private keyboard: PlayerKeyboard = {
         left: false,
@@ -25,35 +14,20 @@ export class GameKeyboard {
         ctrl: false,
     };
 
-    private onKeyChange?: keyboardChangeCallback;
+    private callback?: keyboardChangeCallback;
 
     public init(callback: keyboardChangeCallback) {
-        this.onKeyChange = callback;
+        this.callback = callback;
     }
 
-    public onKeyDown(keyString: string, event: KeyboardEvent) {
-        const inMap = keyString in keyMap;
-        if (!inMap) return;
-        event.preventDefault();
-        const key = keyMap[keyString];
-        const keyAlreadyPressed = this.keyboard[key];
+    public onKeyChange(action: GameAction, type: "up" | "down") {
+        const currentlyPressed = this.keyboard[action];
+        const nextPressed = type === "down";
+        const keyChanged = currentlyPressed !== nextPressed;
+        if (!keyChanged) return;
 
-        if (!keyAlreadyPressed) {
-            this.keyboard[key] = true;
-            if (this.onKeyChange) {
-                this.onKeyChange(structuredClone(this.keyboard));
-            }
-        }
-    }
+        this.keyboard[action] = nextPressed;
 
-    public onKeyUp(keyString: string, event: KeyboardEvent) {
-        const inMap = keyString in keyMap;
-        if (!inMap) return;
-        event.preventDefault();
-        const key = keyMap[keyString];
-        this.keyboard[key] = false;
-        if (this.onKeyChange) {
-            this.onKeyChange(structuredClone(this.keyboard));
-        }
+        this.callback?.(structuredClone(this.keyboard));
     }
 }

--- a/client/src/helpers.ts
+++ b/client/src/helpers.ts
@@ -1,3 +1,11 @@
 export function randomGuid() {
     return crypto.randomUUID();
 }
+
+/**
+ * Useful in switch statements.
+ * Ensures that all possible cases have been tested on type level.
+ */
+export function assertNever(value: never, message?: string) {
+    throw new Error(`${message ?? "Expected to never get here, got value"}: ${value}`);
+}

--- a/client/src/hooks/keybinds/models.ts
+++ b/client/src/hooks/keybinds/models.ts
@@ -1,0 +1,19 @@
+import { PlayerKeyboard } from "dogfight-types/PlayerKeyboard";
+
+// Different actions that can be run through keyboard input (as unions)
+
+export type GlobalAction = "scoreboard";
+export type GameAction = keyof PlayerKeyboard;
+export type DevAction = "debug";
+
+export type Keybind<T extends string> = {
+    key: string;
+    action: T;
+};
+
+export type KeybindCallback<T extends string> = (action: T, type: "up" | "down", event: KeyboardEvent) => void;
+
+export type KeybindConfig<T extends string> = {
+    callback: KeybindCallback<T>;
+    keybinds: Keybind<T>[];
+};

--- a/client/src/hooks/keybinds/registerKeybinds.ts
+++ b/client/src/hooks/keybinds/registerKeybinds.ts
@@ -1,0 +1,41 @@
+import { Keybind, KeybindConfig } from "./models";
+
+/**
+ * Converting to lowercase to support having shift pressed at the same time
+ * If there is a need to have keybinds with modifiers, they can be implemented alongside the plain keybinds
+ */
+const keybindToIdentifier = <T extends string>(keybind: Keybind<T>) => keybind.key.toLowerCase();
+
+const eventToIdentifier = (e: KeyboardEvent) => e.key.toLowerCase();
+
+export const registerKeybinds = <T extends string>(config: KeybindConfig<T>) => {
+    const callbacks = new Map<string, T[]>();
+
+    for (const keybind of config.keybinds) {
+        const identifier = keybindToIdentifier(keybind);
+        const keybindCallbacks = (callbacks.get(identifier) ?? []).concat(keybind.action);
+        callbacks.set(identifier, keybindCallbacks);
+    }
+
+    const handleKeyEvent = (eventType: "down" | "up") => (event: KeyboardEvent) => {
+        const plainKeybindIdentifier = eventToIdentifier(event);
+        const plainKeybindCallbacks = callbacks.get(plainKeybindIdentifier);
+        if (plainKeybindCallbacks) {
+            for (const action of plainKeybindCallbacks) {
+                config.callback(action, eventType, event);
+            }
+        }
+    };
+
+    const keyup = handleKeyEvent("up");
+
+    const keydown = handleKeyEvent("down");
+
+    document.addEventListener("keyup", keyup);
+    document.addEventListener("keydown", keydown);
+
+    return function unregisterCallbacks() {
+        document.removeEventListener("keyup", keyup);
+        document.removeEventListener("keydown", keydown);
+    };
+};

--- a/client/src/hooks/keybinds/useDevKeybinds.ts
+++ b/client/src/hooks/keybinds/useDevKeybinds.ts
@@ -1,0 +1,40 @@
+import { DebugEntity } from "dogfight-types/DebugEntity";
+import { registerKeybinds } from "./registerKeybinds";
+import { DogfightWeb } from "dogfight-web";
+import { DogfightClient } from "../../client/DogfightClient";
+import { useEffect } from "react";
+import { DevAction, KeybindCallback, KeybindConfig } from "./models";
+import { assertNever } from "../../helpers";
+
+export const useDevKeybinds = ({ client, engine }: { client: DogfightClient; engine: DogfightWeb }) => {
+    const handleEvent: KeybindCallback<DevAction> = (action, type) => {
+        if (type === "down") return;
+        switch (action) {
+            case "debug": {
+                const debugInfo: DebugEntity[] = JSON.parse(engine.debug());
+                client.renderDebug(debugInfo);
+                return;
+            }
+            default:
+                assertNever(action);
+        }
+    };
+
+    const keybinds: KeybindConfig<DevAction> = {
+        callback: handleEvent,
+        keybinds: [
+            {
+                key: "d",
+                action: "debug",
+            },
+        ],
+    };
+
+    useEffect(() => {
+        if (!import.meta.env.DEV) return;
+
+        const unregisterKeybinds = registerKeybinds(keybinds);
+
+        return unregisterKeybinds;
+    }, []);
+};

--- a/client/src/hooks/keybinds/useGameKeybinds.ts
+++ b/client/src/hooks/keybinds/useGameKeybinds.ts
@@ -1,0 +1,26 @@
+import { registerKeybinds } from "./registerKeybinds";
+import { useEffect } from "react";
+import { DogfightWeb } from "dogfight-web";
+import { DogfightClient } from "../../client/DogfightClient";
+import { useSettingsContext } from "../../contexts/settingsContext";
+import { GameAction, KeybindCallback, KeybindConfig } from "./models";
+
+export const useGameKeybinds = ({ client }: { client: DogfightClient; engine: DogfightWeb }) => {
+    const { settings } = useSettingsContext();
+
+    const handleEvent: KeybindCallback<GameAction> = (action, type, event) => {
+        event.preventDefault();
+        client.keyboard.onKeyChange(action, type);
+    };
+
+    const keybinds: KeybindConfig<GameAction> = {
+        callback: handleEvent,
+        keybinds: settings.controls,
+    };
+
+    useEffect(() => {
+        const unregisterKeybinds = registerKeybinds(keybinds);
+
+        return unregisterKeybinds;
+    }, [client.keyboard]);
+};

--- a/client/src/hooks/keybinds/useGlobalKeybinds.ts
+++ b/client/src/hooks/keybinds/useGlobalKeybinds.ts
@@ -1,0 +1,33 @@
+import { assertNever } from "../../helpers";
+import { GlobalAction, KeybindCallback, KeybindConfig } from "./models";
+import { registerKeybinds } from "./registerKeybinds";
+import { useEffect } from "react";
+
+export const useGlobalKeybinds = ({ toggleScoreboard }: { toggleScoreboard: (enabled: boolean) => void }) => {
+    const handleEvent: KeybindCallback<GlobalAction> = (action, type, event) => {
+        event.preventDefault();
+        switch (action) {
+            case "scoreboard": {
+                return toggleScoreboard(type === "down");
+            }
+            default:
+                assertNever(action);
+        }
+    };
+
+    const keybinds: KeybindConfig<GlobalAction> = {
+        callback: handleEvent,
+        keybinds: [
+            {
+                action: "scoreboard",
+                key: "tab",
+            },
+        ],
+    };
+
+    useEffect(() => {
+        const unregisterKeybinds = registerKeybinds(keybinds);
+
+        return unregisterKeybinds;
+    }, []);
+};


### PR DESCRIPTION
relates https://github.com/mattbruv/Lentokonepeli/issues/48

- add unified way to handle keyup / down events
- update settings page to use the new format internally
- __change settings localstorage key to v2__, so that old type of keybinds wont interfere with the new ones


Also, I'm not sure if "GlobalKeybinds" and toggling scoreboard, go hand in hand conceptually. I suppose the scoreboard toggling could also be inside the GameKeybinds. But adjusting this stuff is easy now.
