### PR TITLE
implement gameloop with requestAnimationFrame

### DIFF
--- a/client/src/client/entities/backgroundItem.ts
+++ b/client/src/client/entities/backgroundItem.ts
@@ -4,6 +4,7 @@ import * as PIXI from "pixi.js";
 import { DrawLayer } from "../constants";
 import { Textures } from "../textures";
 import { Entity, EntityUpdateCallbacks } from "./entity";
+import { animationRunner } from "../../gameLoop";
 
 type FlagTypes = "FlagAllies" | "FlagCentrals";
 
@@ -24,7 +25,6 @@ export class BackgroundItem implements Entity<BackgroundItemProperties> {
 
     private itemTextures: Record<BackgroundItemType, PIXI.Texture>;
     private flagTypes: BackgroundItemType[];
-    private flagInterval: number | null = null;
     private flagTextures: FlagTextureMap;
     private flagIndex = 0;
 
@@ -66,20 +66,21 @@ export class BackgroundItem implements Entity<BackgroundItemProperties> {
         return this.container;
     }
 
+    private animate = () => {
+        this.waveFlag();
+    };
+
     public updateCallbacks: EntityUpdateCallbacks<BackgroundItemProperties> = {
         bg_item_type: () => {
             const { bg_item_type } = this.props;
             if (bg_item_type === undefined) return;
             if (!this.props.bg_item_type) return;
-            if (this.flagInterval !== null) {
-                clearInterval(this.flagInterval);
-            }
 
             const texture = this.itemTextures[bg_item_type];
             this.itemSprite.texture = texture;
 
             if (this.flagTypes.includes(bg_item_type)) {
-                this.flagInterval = window.setInterval(() => this.waveFlag(), 100);
+                animationRunner.registerAnimation(this.animate, 10);
             }
         },
         facing: () => {
@@ -118,8 +119,6 @@ export class BackgroundItem implements Entity<BackgroundItemProperties> {
     }
 
     public destroy() {
-        if (this.flagInterval !== null) {
-            clearInterval(this.flagInterval);
-        }
+        animationRunner.unregisterAnimation(this.animate);
     }
 }

--- a/client/src/client/entities/bullet.ts
+++ b/client/src/client/entities/bullet.ts
@@ -4,6 +4,7 @@ import { Howl } from "howler";
 import { BulletProperties } from "dogfight-types/BulletProperties";
 import { directionToRadians } from "../helpers";
 import { DrawLayer } from "../constants";
+import { animationRunner } from "../../gameLoop";
 
 const COLORS: string[] = ["#000000", "#171717", "#515151", "#606060", "#999999"];
 
@@ -13,7 +14,6 @@ export class Bullet implements Entity<BulletProperties> {
 
     private sound: Howl;
     private age = 1;
-    private bullet_interval: number;
 
     public isGameRunning: boolean = true;
 
@@ -22,6 +22,12 @@ export class Bullet implements Entity<BulletProperties> {
         client_y: 0,
         speed: 0,
         direction: 0,
+    };
+
+    private animate = () => {
+        if (this.isGameRunning) {
+            this.move_bullet();
+        }
     };
 
     constructor() {
@@ -46,11 +52,7 @@ export class Bullet implements Entity<BulletProperties> {
 
         this.container.zIndex = DrawLayer.Bullet;
 
-        this.bullet_interval = window.setInterval(() => {
-            if (this.isGameRunning) {
-                this.move_bullet();
-            }
-        }, 10);
+        animationRunner.registerAnimation(this.animate, 1);
     }
 
     private move_bullet() {
@@ -99,6 +101,6 @@ export class Bullet implements Entity<BulletProperties> {
 
     public destroy() {
         this.sound.stop();
-        window.clearInterval(this.bullet_interval);
+        animationRunner.unregisterAnimation(this.animate);
     }
 }

--- a/client/src/client/entities/man.ts
+++ b/client/src/client/entities/man.ts
@@ -6,6 +6,7 @@ import { ManProperties } from "dogfight-types/ManProperties";
 import { Stats } from "../hud";
 import { RadarObject, RadarObjectType } from "../radar";
 import { Team } from "dogfight-types/Team";
+import { animationRunner } from "../../gameLoop";
 
 export class Man implements Entity<ManProperties>, Followable, RadarEnabled {
     public props: Required<ManProperties> = {
@@ -19,10 +20,13 @@ export class Man implements Entity<ManProperties>, Followable, RadarEnabled {
     private manContainer: PIXI.Container;
 
     private manSprite: PIXI.Sprite;
-    private walkAnim: number | null = null;
 
     private nameText: PIXI.Text;
     private frameCount = 0;
+
+    private animate = () => {
+        this.animateWalk();
+    };
 
     constructor() {
         this.container = new PIXI.Container();
@@ -49,7 +53,7 @@ export class Man implements Entity<ManProperties>, Followable, RadarEnabled {
 
         this.container.zIndex = DrawLayer.Man;
 
-        this.walkAnim = window.setInterval(() => this.animateWalk(), 100);
+        animationRunner.registerAnimation(this.animate, 10);
     }
 
     public callbackOrder: (keyof ManProperties)[] = ["client_x", "client_y"];
@@ -81,7 +85,7 @@ export class Man implements Entity<ManProperties>, Followable, RadarEnabled {
     }
 
     public destroy() {
-        if (this.walkAnim) window.clearInterval(this.walkAnim);
+        animationRunner.unregisterAnimation(this.animate);
     }
 
     private updateX(): void {

--- a/client/src/client/entities/water.ts
+++ b/client/src/client/entities/water.ts
@@ -3,6 +3,7 @@ import * as PIXI from "pixi.js";
 import { DrawLayer, TERRAIN_WATER_COLOR } from "../constants";
 import { Textures } from "../textures";
 import { Entity, EntityUpdateCallbacks } from "./entity";
+import { animationRunner } from "../../gameLoop";
 
 export class Water implements Entity<WaterProperties> {
     public props: Required<WaterProperties> = {
@@ -17,7 +18,10 @@ export class Water implements Entity<WaterProperties> {
     private waves: PIXI.TilingSprite;
 
     private waveIndex = 0;
-    private waveInterval: number;
+
+    private animate = () => {
+        this.waveStep();
+    };
 
     constructor() {
         this.container = new PIXI.Container();
@@ -27,9 +31,7 @@ export class Water implements Entity<WaterProperties> {
         this.waves = new PIXI.TilingSprite(wave1);
         this.waves.height = wave1.height;
 
-        this.waveInterval = window.setInterval(() => {
-            this.waveStep();
-        }, 200);
+        animationRunner.registerAnimation(this.animate, 20);
 
         this.container.addChild(this.waterGraphics);
         this.container.addChild(this.waves);
@@ -100,6 +102,6 @@ export class Water implements Entity<WaterProperties> {
     }
 
     public destroy() {
-        window.clearInterval(this.waveInterval);
+        animationRunner.unregisterAnimation(this.animate);
     }
 }

--- a/client/src/gameLoop.ts
+++ b/client/src/gameLoop.ts
@@ -25,17 +25,18 @@ class GameLoop {
     }
 
     private gameLoop = (time: number) => {
-        this.requestId = requestAnimationFrame(this.gameLoop);
-
         let delta = time - this.lastTime;
-        while (delta >= this.tickInterval) {
-            this.currentTick++;
-            delta -= this.tickInterval;
+        if (delta >= this.tickInterval) {
+            while (delta >= this.tickInterval) {
+                this.currentTick++;
+                delta -= this.tickInterval;
+                this.updateFn(this.currentTick);
+                this.animationRunner.runAnimations(this.currentTick);
+            }
             this.lastTime += this.tickInterval;
-
-            this.updateFn(this.currentTick);
-            this.animationRunner.runAnimations(this.currentTick);
         }
+
+        this.requestId = requestAnimationFrame(this.gameLoop);
     };
 
     private startLoop() {

--- a/client/src/gameLoop.ts
+++ b/client/src/gameLoop.ts
@@ -4,7 +4,6 @@ const noop = () => {};
 class GameLoop {
     private currentTick: number = 0;
     private lastTime: number = performance.now();
-    private isRunning: boolean = false;
     private requestId: number | null = null;
     private tickInterval: number = 10;
     private updateFn: UpdateFn = noop;
@@ -39,21 +38,19 @@ class GameLoop {
     };
 
     private startLoop() {
-        if (this.isRunning) return;
-        this.isRunning = true;
+        if (this.requestId) return;
         this.lastTime = performance.now();
         this.requestId = requestAnimationFrame(this.gameLoop);
     }
 
     private pauseLoop() {
-        this.isRunning = false;
         if (!this.requestId) return;
         cancelAnimationFrame(this.requestId);
         this.requestId = null;
     }
 
     public start() {
-        if (this.isRunning) return;
+        if (this.requestId) return;
         this.currentTick = 0;
         this.lastTime = performance.now();
         this.startLoop();

--- a/client/src/gameLoop.ts
+++ b/client/src/gameLoop.ts
@@ -26,13 +26,12 @@ class GameLoop {
 
     private gameLoop = (time: number) => {
         let delta = time - this.lastTime;
-        if (delta >= this.tickInterval) {
-            while (delta >= this.tickInterval) {
-                this.currentTick++;
-                delta -= this.tickInterval;
-                this.updateFn(this.currentTick);
-                this.animationRunner.runAnimations(this.currentTick);
-            }
+
+        while (delta >= this.tickInterval) {
+            this.currentTick++;
+            delta -= this.tickInterval;
+            this.updateFn(this.currentTick);
+            this.animationRunner.runAnimations(this.currentTick);
             this.lastTime += this.tickInterval;
         }
 
@@ -40,22 +39,21 @@ class GameLoop {
     };
 
     private startLoop() {
-        if (!this.isRunning) {
-            this.isRunning = true;
-            this.lastTime = performance.now();
-            this.requestId = requestAnimationFrame(this.gameLoop);
-        }
+        if (this.isRunning) return;
+        this.isRunning = true;
+        this.lastTime = performance.now();
+        this.requestId = requestAnimationFrame(this.gameLoop);
     }
 
     private pauseLoop() {
         this.isRunning = false;
-        if (this.requestId !== null) {
-            cancelAnimationFrame(this.requestId);
-            this.requestId = null;
-        }
+        if (!this.requestId) return;
+        cancelAnimationFrame(this.requestId);
+        this.requestId = null;
     }
 
     public start() {
+        if (this.isRunning) return;
         this.currentTick = 0;
         this.lastTime = performance.now();
         this.startLoop();

--- a/client/src/gameLoop.ts
+++ b/client/src/gameLoop.ts
@@ -1,0 +1,91 @@
+type UpdateFn = (currentTick: number) => void;
+const noop = () => {};
+
+class GameLoop {
+    private currentTick: number = 0;
+    private lastTime: number = performance.now();
+    private isRunning: boolean = false;
+    private requestId: number | null = null;
+    private tickInterval: number = 10;
+    private updateFn: UpdateFn = noop;
+    private animationRunner: AnimationRunner;
+
+    constructor(animationRunner: AnimationRunner) {
+        this.animationRunner = animationRunner;
+    }
+
+    public setTickInterval(tickInterval: number) {
+        this.tickInterval = tickInterval;
+        return this;
+    }
+
+    public setHostEngineUpdateFn(updateFn: UpdateFn) {
+        this.updateFn = updateFn;
+        return this;
+    }
+
+    private gameLoop = (time: number) => {
+        this.requestId = requestAnimationFrame(this.gameLoop);
+
+        let delta = time - this.lastTime;
+        while (delta >= this.tickInterval) {
+            this.currentTick++;
+            delta -= this.tickInterval;
+            this.lastTime += this.tickInterval;
+
+            this.updateFn(this.currentTick);
+            this.animationRunner.runAnimations(this.currentTick);
+        }
+    };
+
+    private startLoop() {
+        if (!this.isRunning) {
+            this.isRunning = true;
+            this.lastTime = performance.now();
+            this.requestId = requestAnimationFrame(this.gameLoop);
+        }
+    }
+
+    private pauseLoop() {
+        this.isRunning = false;
+        if (this.requestId !== null) {
+            cancelAnimationFrame(this.requestId);
+            this.requestId = null;
+        }
+    }
+
+    public start() {
+        this.currentTick = 0;
+        this.lastTime = performance.now();
+        this.startLoop();
+    }
+
+    public pause() {
+        this.pauseLoop();
+    }
+
+    public continue() {
+        this.startLoop();
+    }
+}
+
+class AnimationRunner {
+    private animations: Map<UpdateFn, number> = new Map();
+
+    registerAnimation(animation: UpdateFn, tickInterval: number) {
+        this.animations.set(animation, tickInterval);
+    }
+
+    unregisterAnimation(animation: UpdateFn) {
+        this.animations.delete(animation);
+    }
+
+    runAnimations(currentTick: number) {
+        for (const [animate, tickInterval] of this.animations.entries()) {
+            if (currentTick % tickInterval === 0) animate(currentTick);
+        }
+    }
+}
+
+export const animationRunner = new AnimationRunner();
+export const gameLoop = new GameLoop(animationRunner).setTickInterval(10);

--- a/client/src/hooks/useGuest.ts
+++ b/client/src/hooks/useGuest.ts
@@ -4,6 +4,7 @@ import Peer from "peerjs";
 import { PlayerCommand } from "dogfight-types/PlayerCommand";
 import { ServerOutput } from "dogfight-types/ServerOutput";
 import { PeerJSPath } from "./useLocalHost";
+import { gameLoop } from "../gameLoop";
 
 export function useGuest(myName: string, clan: string) {
     const peer = useRef<Peer | null>(null);
@@ -29,6 +30,7 @@ export function useGuest(myName: string, clan: string) {
         peer.current.on("open", (x) => {
             console.log("Guest:", x);
 
+            gameLoop.start();
             const conn = peer.current!.connect(PeerJSPath(roomId));
 
             conn.on("open", () => {
@@ -70,6 +72,7 @@ export function useGuest(myName: string, clan: string) {
             console.log("destroy guest");
             peer.current?.removeAllListeners();
             peer.current?.destroy();
+            gameLoop.pause();
         };
     }, []);
 


### PR DESCRIPTION
closes https://github.com/mattbruv/Lentokonepeli/issues/22

Implement the gameloop as a single requestAnimationFrame loop as described in https://github.com/mattbruv/Lentokonepeli/issues/22#issuecomment-2736776911

Should fix firefox concerns and be more performant across the board.

Now, this is a draft because I failed to test the peer connections. Maybe I am starting the gameLoop in a wrong place when acting as a guest. Or the test can't be done on a single machine.

