### PR TITLE
Correct motor delay

### DIFF
--- a/dogfight/Cargo.toml
+++ b/dogfight/Cargo.toml
@@ -1,7 +1,7 @@
 workspace = { members = ["dogfight-macros", "dogfight-web"] }
 [package]
 name = "dogfight"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/dogfight/src/entities/plane.rs
+++ b/dogfight/src/entities/plane.rs
@@ -174,7 +174,7 @@ impl Plane {
             last_shot_ms: 0,
 
             last_motor_on_ms: 0,
-            motor_on_delay_ms: 500,
+            motor_on_delay_ms: 200,
 
             takeoff_counter: 0,
             dodge_counter: 0,


### PR DESCRIPTION
closes https://github.com/mattbruv/Lentokonepeli/issues/57

Issue was simple, in the original code the motor delay was 200 ms, while this implementation had set it to 500 ms. Possibly due to copy pasta from above lines, or what ever.

[Original source](https://github.com/mattbruv/dogfight-source/blob/main/com/aapeli/multiplayer/impl/dogfight/server/entities/Plane.java#L52C1-L52C36)
