### PR TITLE
Original bounding box for man

### DIFF
--- a/dogfight/Cargo.toml
+++ b/dogfight/Cargo.toml
@@ -1,7 +1,7 @@
 workspace = { members = ["dogfight-macros", "dogfight-web"] }
 [package]
 name = "dogfight"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/dogfight/src/entities/man.rs
+++ b/dogfight/src/entities/man.rs
@@ -260,16 +260,13 @@ impl SolidEntity for Man {
         BoundingBox {
             x: (self.x / RESOLUTION) as i16,
             y: (self.y / RESOLUTION) as i16,
-            width: self.image_parachuting.width() as i16,
-            height: self.image_parachuting.height() as i16,
+            width: self.image_standing.width() as i16,
+            height: self.image_standing.height() as i16,
         }
     }
 
     fn get_collision_image(&self) -> Option<&RgbaImage> {
-        match self.state.get() {
-            ManState::Parachuting => Some(&self.image_parachuting),
-            _ => Some(&self.image_standing),
-        }
+        Some(&self.image_standing)
     }
 
     fn do_rotate_collision_image(&mut self) -> () {}


### PR DESCRIPTION
closes https://github.com/mattbruv/Lentokonepeli/issues/44

in original source the bounding box was always based on the 0th image (standing man)

All the gif files have the same resolution, so I suppose the `images::get_image` automatically removes fully opaque pixels or something?

Nevertheless, changing to the standing image allows the man to stand in between the hangars in Katala.

<img width="645" alt="Näyttökuva 2025-03-24 kello 15 31 01" src="https://github.com/user-attachments/assets/2413a8a9-ed73-48b2-83d0-d17c1af8c142" />
<img width="150" alt="Näyttökuva 2025-03-24 kello 15 36 27" src="https://github.com/user-attachments/assets/aa0c8244-bd3f-42b0-a5b8-db26aed514f8" />
