### PR TITLE
Streamline client code

### DIFF
--- a/client/src/client/DogfightClient.ts
+++ b/client/src/client/DogfightClient.ts
@@ -250,23 +250,13 @@ export class DogfightClient {
     }
 
     private updateRadar() {
-        const objs: RadarObject[] = [];
-
-        const radarObjs: Record<RadarObjectType, EntityGroup<RadarEnabled>> = {
-            [RadarObjectType.Ground]: this.entities.Ground,
-            [RadarObjectType.Man]: this.entities.Man,
-            [RadarObjectType.Plane]: this.entities.Plane,
-            [RadarObjectType.Runway]: this.entities.Runway,
-            [RadarObjectType.Bunker]: this.entities.Bunker,
-        };
-
-        for (const [_, objects] of Object.entries(radarObjs)) {
-            for (const [_, obj] of objects.collection) {
-                objs.push(obj.getRadarInfo());
-            }
-        }
-
-        this.gameHUD.radar.refreshRadar(objs);
+        this.gameHUD.radar.refreshRadar([
+            this.entities.Ground,
+            this.entities.Man,
+            this.entities.Plane,
+            this.entities.Runway,
+            this.entities.Bunker,
+        ]);
     }
 
     public handleGameEvents(events: ServerOutput[]) {

--- a/client/src/client/DogfightClient.ts
+++ b/client/src/client/DogfightClient.ts
@@ -22,7 +22,7 @@ import { KillFeed } from "./killfeed";
 import { RadarObject, RadarObjectType } from "./radar";
 import { RunwaySelector } from "./runwaySelector";
 import { TeamChooser } from "./teamChooser";
-import { loadTextures, Textures } from "./textures";
+import { Textures } from "./textures";
 
 export type GameClientCallbacks = {
     chooseTeam: (team: Team | null) => void;
@@ -169,7 +169,6 @@ export class DogfightClient {
     }
 
     public async init(callbacks: GameClientCallbacks, element: HTMLDivElement, intl: IntlShape) {
-        await loadTextures();
         this.appendView(element);
         this.callbacks = callbacks;
         this.teamChooser.init(this.callbacks);

--- a/client/src/client/DogfightClient.ts
+++ b/client/src/client/DogfightClient.ts
@@ -66,8 +66,6 @@ export class DogfightClient {
     private killFeed: KillFeed = new KillFeed();
     public keyboard: GameKeyboard = new GameKeyboard();
 
-    private debug: PIXI.Graphics = new PIXI.Graphics();
-
     private callbacks?: GameClientCallbacks;
     private sendPlayerUpdate: boolean = false;
     public entities = entityCollection([...DEFAULT_ENTITIES, ["Player", createNewPlayer.bind(this)]]);
@@ -158,9 +156,6 @@ export class DogfightClient {
             this.runwaySelector.container.position.set(x, y);
         }
 
-        window.setTimeout(() => {
-            this.renderClient.viewport.addChild(this.debug);
-        }, 100);
         this.centerCamera(0, 0);
     }
 

--- a/client/src/client/DogfightClient.ts
+++ b/client/src/client/DogfightClient.ts
@@ -168,7 +168,7 @@ export class DogfightClient {
         }
     }
 
-    public async init(callbacks: GameClientCallbacks, element: HTMLDivElement, intl: IntlShape) {
+    public init(callbacks: GameClientCallbacks, element: HTMLDivElement, intl: IntlShape) {
         this.appendView(element);
         this.callbacks = callbacks;
         this.teamChooser.init(this.callbacks);

--- a/client/src/client/DogfightClient.ts
+++ b/client/src/client/DogfightClient.ts
@@ -11,7 +11,7 @@ import * as PIXI from "pixi.js";
 import { IntlShape } from "react-intl";
 import { isFollowable, updateProps } from "./entities/entity";
 import { Player } from "./entities/player";
-import { DEFAULT_ENTITIES, destroyEntities, entityCollection } from "./EntityManager";
+import { DEFAULT_ENTITIES, entityCollection } from "./EntityManager";
 import { formatName } from "./helpers";
 import { GameHUD } from "./hud";
 import { GameKeyboard } from "./keyboard";
@@ -159,9 +159,21 @@ export class DogfightClient {
         this.centerCamera(0, 0);
     }
 
+    private destroyEntities() {
+        for (const group of Object.values(this.entities)) {
+            for (const [id, entity] of group.collection.entries()) {
+                const container = entity.getContainer();
+                const containers = Array.isArray(container) ? container : [container];
+                this.renderClient.viewport.removeChild(...containers);
+                entity.destroy();
+                group.collection.delete(id);
+            }
+        }
+    }
+
     public destroy() {
         console.log("destroying client...");
-        destroyEntities(this.entities);
+        this.destroyEntities();
 
         this.renderClient.app.destroy(true, {
             children: true,

--- a/client/src/client/EntityManager.ts
+++ b/client/src/client/EntityManager.ts
@@ -1,0 +1,76 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { EntityProperties } from "dogfight-types/EntityProperties";
+import { BackgroundItem } from "./entities/backgroundItem";
+import { Bomb } from "./entities/bomb";
+import { Bullet } from "./entities/bullet";
+import { Bunker } from "./entities/bunker";
+import { Coast } from "./entities/coast";
+import { Explosion } from "./entities/explosion";
+import { Ground } from "./entities/ground";
+import { Hill } from "./entities/hill";
+import { Man } from "./entities/man";
+import { Plane } from "./entities/plane";
+import { Runway } from "./entities/runway";
+import { Water } from "./entities/water";
+import { WorldInfo } from "./entities/worldInfo";
+
+export type EntityType = EntityProperties["type"];
+
+export type EntityGroup<T> = {
+    new_type: () => T;
+    collection: Map<number, T>;
+};
+
+type Constructor<T> = () => T;
+
+type EntityManagerEntry<T extends EntityType, C> = [type: T, constructor: Constructor<C>];
+
+type EntityCollection<T extends EntityType, E extends EntityManagerEntry<EntityType, any>> = {
+    [K in T]: EntityGroup<Extract<E, [K, Constructor<any>]> extends [K, Constructor<infer U>] ? U : never>;
+};
+
+/**
+ * Player added later where needed as it requires its own kind of construction
+ */
+export const DEFAULT_ENTITIES = [
+    ["WorldInfo", () => new WorldInfo()],
+    ["Plane", () => new Plane()],
+    ["Man", () => new Man()],
+    ["BackgroundItem", () => new BackgroundItem()],
+    ["Ground", () => new Ground()],
+    ["Coast", () => new Coast()],
+    ["Runway", () => new Runway()],
+    ["Water", () => new Water()],
+    ["Bunker", () => new Bunker()],
+    ["Bomb", () => new Bomb()],
+    ["Explosion", () => new Explosion()],
+    ["Hill", () => new Hill()],
+    ["Bullet", () => new Bullet()],
+] as const satisfies EntityManagerEntry<EntityType, any>[];
+
+/**
+ * In typesafe manner create entity collection where only the provided entities are in the result type
+ */
+export function entityCollection<T extends EntityType, E extends EntityManagerEntry<T, any>>(entries: E[]) {
+    const entities: Partial<EntityCollection<T, E>> = {};
+
+    for (const [name, constructor] of entries) {
+        entities[name] = {
+            new_type: constructor,
+            collection: new Map(),
+        };
+    }
+
+    return entities as EntityCollection<T, E>;
+}
+
+export function destroyEntities(entities: EntityCollection<any, any>) {
+    console.log("destroying entities...");
+    for (const group of Object.values(entities)) {
+        if (group) {
+            for (const entity of (group as EntityGroup<any>).collection.values()) {
+                entity.destroy();
+            }
+        }
+    }
+}

--- a/client/src/client/EntityManager.ts
+++ b/client/src/client/EntityManager.ts
@@ -54,15 +54,3 @@ export function entityCollection<E extends EntityEntry<EntityType, any>[]>(entri
         entries.map(([name, constructor]) => [name, { new_type: constructor, collection: new Map() }]),
     ) as EntityCollection<E>;
 }
-
-/**
- * Destroys all entities in the collection
- */
-export function destroyEntities(entities: EntityCollection<any>) {
-    console.log("Destroying entities...");
-    for (const group of Object.values(entities)) {
-        for (const entity of group.collection.values()) {
-            entity.destroy();
-        }
-    }
-}

--- a/client/src/client/EntityManager.ts
+++ b/client/src/client/EntityManager.ts
@@ -1,10 +1,10 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { EntityProperties } from "dogfight-types/EntityProperties";
 import { BackgroundItem } from "./entities/backgroundItem";
 import { Bomb } from "./entities/bomb";
 import { Bullet } from "./entities/bullet";
 import { Bunker } from "./entities/bunker";
 import { Coast } from "./entities/coast";
+import { Entity } from "./entities/entity";
 import { Explosion } from "./entities/explosion";
 import { Ground } from "./entities/ground";
 import { Hill } from "./entities/hill";
@@ -23,7 +23,7 @@ export type EntityGroup<T> = {
 
 type EntityEntry<T extends EntityType, C> = [T, () => C];
 
-type EntityCollection<E extends EntityEntry<EntityType, any>[]> = {
+type EntityCollection<E extends EntityEntry<EntityType, Entity<unknown>>[]> = {
     [K in E[number] as K[0]]: EntityGroup<ReturnType<K[1]>>;
 };
 
@@ -44,12 +44,12 @@ export const DEFAULT_ENTITIES = [
     ["Explosion", () => new Explosion()],
     ["Hill", () => new Hill()],
     ["Bullet", () => new Bullet()],
-] as const satisfies EntityEntry<EntityType, any>[];
+] as const satisfies EntityEntry<EntityType, Entity<unknown>>[];
 
 /**
  * Creates an entity collection with strict type safety
  */
-export function entityCollection<E extends EntityEntry<EntityType, any>[]>(entries: E) {
+export function entityCollection<E extends EntityEntry<EntityType, Entity<unknown>>[]>(entries: E) {
     return Object.fromEntries(
         entries.map(([name, constructor]) => [name, { new_type: constructor, collection: new Map() }]),
     ) as EntityCollection<E>;

--- a/client/src/client/RenderClient.ts
+++ b/client/src/client/RenderClient.ts
@@ -1,0 +1,147 @@
+import { DebugEntity } from "dogfight-types/DebugEntity";
+import { EntityType } from "dogfight-types/EntityType";
+import { Viewport } from "pixi-viewport";
+import * as PIXI from "pixi.js";
+import { SKY_COLOR, VIEW_HEIGHT, VIEW_WIDTH } from "./constants";
+
+export class RenderClient {
+    // https://pixijs.download/v7.x/docs/index.html
+    public app: PIXI.Application<HTMLCanvasElement>;
+    public viewport: Viewport;
+    public background: PIXI.TilingSprite;
+    public hud: PIXI.Container | null;
+
+    // Debugging helpers
+    public debugPointer = new PIXI.Text();
+    public debugCoords = new PIXI.Text();
+    public debugCollision = new PIXI.Graphics();
+
+    constructor({
+        background,
+        containers,
+        hud,
+    }: {
+        hud: PIXI.Container | null;
+        background: PIXI.TilingSprite;
+        containers: PIXI.DisplayObject[];
+    }) {
+        this.app = new PIXI.Application<HTMLCanvasElement>({
+            antialias: false,
+            resolution: 1,
+            backgroundColor: SKY_COLOR,
+            width: VIEW_WIDTH,
+            height: VIEW_HEIGHT,
+        });
+
+        this.background = background;
+
+        this.app.stage.addChild(background);
+
+        this.viewport = new Viewport({
+            events: this.app.renderer.events,
+        });
+        this.app.stage.addChild(this.viewport);
+
+        this.hud = hud;
+
+        if (hud) {
+            this.app.stage.addChild(hud);
+        }
+
+        this.app.stage.addChild(...containers);
+
+        this.viewport.sortableChildren = true;
+
+        if (import.meta.env.DEV) {
+            this.viewport.drag().pinch().wheel().decelerate();
+            this.app.stage.addChild(this.debugPointer);
+            this.app.stage.addChild(this.debugCoords);
+            this.viewport.addChild(this.debugCollision);
+            this.debugCollision.zIndex = 999;
+            this.debugCoords.position.set(0, 30);
+            this.debugPointer.style.fontFamily = "monospace";
+            this.debugCoords.style.fontFamily = "monospace";
+
+            this.viewport.onpointermove = (e) => {
+                const pos = this.viewport.toWorld(e.data.global);
+                const x = Math.round(pos.x);
+                const y = Math.round(pos.y);
+                this.debugPointer.text = `${x}, ${y}`;
+            };
+        }
+    }
+
+    private positionRelativeGameObjects(x: number, y: number) {
+        const x1 = x / 6;
+        const y1 = y / 3 + 125;
+
+        // reposition sky
+        this.background.tilePosition.set(-x1, -y1);
+
+        // TODO handle parallax for hills and stuff
+    }
+
+    /**
+     * Center the camera view on a specific (x, y) location
+     * Coordinates must be in game world space.
+     */
+    public centerCamera(x: number, y: number): void {
+        const x1 = x - this.app.screen.width / 2;
+        const y1 = y - (this.app.screen.height - (this.hud?.height ?? 0)) / 2;
+
+        this.viewport.moveCorner(x1, y1);
+        this.positionRelativeGameObjects(x, y);
+    }
+
+    public renderDebug(debugInfo: DebugEntity[]) {
+        this.debugCollision.clear();
+        this.viewport.sortChildren();
+
+        for (const entry of debugInfo) {
+            this.debugCollision.lineStyle({
+                color: DEBUG_COLORS[entry.ent_type.type],
+                width: 1,
+            });
+
+            if (entry.ent_type.type === "Runway" && !entry.pixels) {
+                this.debugCollision.lineStyle({
+                    color: "magenta",
+                    width: 1,
+                });
+            }
+
+            const { x, y, width, height } = entry.bounding_box;
+
+            // console.log(entry)
+
+            this.debugCollision.drawRect(x, y, width, height);
+
+            if (entry.pixels) {
+                for (const pixel of entry.pixels) {
+                    const px = x + pixel.x;
+                    const py = y + pixel.y;
+                    this.debugCollision.drawRect(px, py, 1, 1);
+                }
+            }
+        }
+
+        this.debugCollision.endFill();
+    }
+}
+
+const DEBUG_COLORS: Record<EntityType, string> = {
+    WorldInfo: "gray",
+    Man: "magenta",
+    Plane: "red",
+    Player: "gray",
+    BackgroundItem: "",
+    Ground: "orange",
+    Coast: "peru",
+    Runway: "purple",
+    Water: "blue",
+    Bunker: "brown",
+    Bomb: "black",
+    Explosion: "lime",
+    Hill: "green",
+    Bullet: "pink",
+};

--- a/client/src/client/RenderClient.ts
+++ b/client/src/client/RenderClient.ts
@@ -15,6 +15,7 @@ export class RenderClient {
     public debugPointer = new PIXI.Text();
     public debugCoords = new PIXI.Text();
     public debugCollision = new PIXI.Graphics();
+    public debug = new PIXI.Graphics();
 
     constructor({
         background,
@@ -69,6 +70,10 @@ export class RenderClient {
                 this.debugPointer.text = `${x}, ${y}`;
             };
         }
+
+        window.setTimeout(() => {
+            this.viewport.addChild(this.debug);
+        }, 100);
     }
 
     private positionRelativeGameObjects(x: number, y: number) {

--- a/client/src/client/RenderClient.ts
+++ b/client/src/client/RenderClient.ts
@@ -69,11 +69,11 @@ export class RenderClient {
                 const y = Math.round(pos.y);
                 this.debugPointer.text = `${x}, ${y}`;
             };
-        }
 
-        window.setTimeout(() => {
-            this.viewport.addChild(this.debug);
-        }, 100);
+            window.setTimeout(() => {
+                this.viewport.addChild(this.debug);
+            }, 100);
+        }
     }
 
     private positionRelativeGameObjects(x: number, y: number) {

--- a/client/src/client/radar.ts
+++ b/client/src/client/radar.ts
@@ -94,14 +94,13 @@ export class Radar {
     }
 
     public refreshRadar(entities: Array<EntityGroup<RadarEnabled>>): void {
+        this.radarGraphics.clear();
         for (const group of entities) {
             for (const [_, obj] of group.collection) {
                 const x = obj.getRadarInfo();
                 this.renderFunctions[x.type](x);
             }
         }
-
-        this.radarGraphics.clear();
     }
 
     private renderObject(obj: RadarObject): void {

--- a/client/src/client/radar.ts
+++ b/client/src/client/radar.ts
@@ -1,5 +1,7 @@
-import * as PIXI from "pixi.js";
 import { Team } from "dogfight-types/Team";
+import * as PIXI from "pixi.js";
+import { EntityGroup } from "./EntityManager";
+import { RadarEnabled } from "./entities/entity";
 
 const BackgroundColor = 0xc7d3df;
 
@@ -91,12 +93,15 @@ export class Radar {
         this.myTeam = newTeam;
     }
 
-    public refreshRadar(radarObjects: RadarObject[]): void {
-        this.radarGraphics.clear();
-
-        for (const obj of radarObjects) {
-            this.renderFunctions[obj.type](obj);
+    public refreshRadar(entities: Array<EntityGroup<RadarEnabled>>): void {
+        for (const group of entities) {
+            for (const [_, obj] of group.collection) {
+                const x = obj.getRadarInfo();
+                this.renderFunctions[x.type](x);
+            }
         }
+
+        this.radarGraphics.clear();
     }
 
     private renderObject(obj: RadarObject): void {

--- a/client/src/client/runwaySelector.ts
+++ b/client/src/client/runwaySelector.ts
@@ -2,12 +2,13 @@ import { PlaneType } from "dogfight-types/PlaneType";
 import { PlayerKeyboard } from "dogfight-types/PlayerKeyboard";
 import { Team } from "dogfight-types/Team";
 import * as PIXI from "pixi.js";
-import { EntityGroup, GameClientCallbacks } from "./DogfightClient";
-import { Point } from "./entities/entity";
-import { Runway } from "./entities/runway";
-import { Textures } from "./textures";
 import { IntlShape } from "react-intl";
 import { GAME_INTL } from "../intl/messages";
+import { GameClientCallbacks } from "./DogfightClient";
+import { Point } from "./entities/entity";
+import { Runway } from "./entities/runway";
+import { EntityGroup } from "./EntityManager";
+import { Textures } from "./textures";
 
 type PlaneData = {
     plane_type: PlaneType;
@@ -178,7 +179,7 @@ export class RunwaySelector {
     }
 
     private getMyRunways(runways: EntityGroup<Runway>): [number, Runway][] {
-        return [...runways.entries.entries()]
+        return [...runways.collection.entries()]
             .filter(
                 ([_, runway]) => runway.props.team === this.team,
                 // TODO: health

--- a/client/src/client/textures.ts
+++ b/client/src/client/textures.ts
@@ -5,10 +5,12 @@ export let Textures: TextureMap = {} as unknown as TextureMap;
 export async function loadTextures() {
     const spritesheet = await PIXI.Assets.load<PIXI.Spritesheet>("./images/images.json");
     spritesheet.baseTexture.scaleMode = PIXI.SCALE_MODES.NEAREST;
-    Textures = spritesheet.textures as unknown as TextureMap;
+    const textures = spritesheet.textures as unknown as TextureMap;
+    Textures = textures;
+    return textures;
 }
 
-interface TextureMap {
+export interface TextureMap {
     "beach-l.gif": PIXI.Texture<PIXI.Resource>;
     "beach-l_desert.gif": PIXI.Texture<PIXI.Resource>;
     "beach-r_desert.gif": PIXI.Texture<PIXI.Resource>;

--- a/client/src/components/Guest.tsx
+++ b/client/src/components/Guest.tsx
@@ -18,9 +18,9 @@ export function Guest({ gameCode }: GuestProps) {
         getClan(),
     );
 
-    async function join() {
+    function join() {
         if (!gameContainer.current) return;
-        await initialize(gameContainer.current);
+        initialize(gameContainer.current);
         joinGame(gameCode);
     }
 

--- a/client/src/components/Host.tsx
+++ b/client/src/components/Host.tsx
@@ -23,9 +23,9 @@ export function Host({ level, recordGame }: HostProps) {
     // const [joinId, setJoinId] = useState("")
     // const [tickRate, setTickRate] = useState(100)
 
-    async function host() {
+    function host() {
         if (!gameContainer.current) return;
-        await initialize(gameContainer.current);
+        initialize(gameContainer.current);
         hostGame();
     }
 

--- a/client/src/contexts/textureContext.tsx
+++ b/client/src/contexts/textureContext.tsx
@@ -1,0 +1,18 @@
+import React, { useEffect, useState } from "react";
+import { loadTextures, TextureMap } from "../client/textures";
+
+/**
+ * Ensures that PIXI textures are in memory
+ */
+export function TextureProvider({ children }: { children: React.ReactNode }) {
+    const [textures, setTextures] = useState<TextureMap | null>(null);
+
+    useEffect(() => {
+        if (textures) return;
+        loadTextures().then(setTextures);
+    }, [textures]);
+
+    if (!textures) return <div>Loading...</div>;
+
+    return <>{children}</>;
+}

--- a/client/src/hooks/keybinds/useDevKeybinds.ts
+++ b/client/src/hooks/keybinds/useDevKeybinds.ts
@@ -18,7 +18,7 @@ export const useDevKeybinds = ({ client, engine }: { client: DogfightClient; eng
         switch (action) {
             case "debug": {
                 const debugInfo: DebugEntity[] = JSON.parse(engine.debug());
-                client.renderDebug(debugInfo);
+                client.renderClient.renderDebug(debugInfo);
                 return;
             }
             default:

--- a/client/src/hooks/useDogfight.ts
+++ b/client/src/hooks/useDogfight.ts
@@ -40,7 +40,7 @@ export function useDogfight({ handleClientCommand }: DogfightCallbacks) {
         client.setMyPlayerGuid(guid);
     }
 
-    async function initialize(div: HTMLDivElement): Promise<void> {
+    function initialize(div: HTMLDivElement) {
         // TODO: clean this up, just expose the onCommand directly in the client
         // and write out the command in the client
         const client_callbacks: GameClientCallbacks = {
@@ -97,7 +97,7 @@ export function useDogfight({ handleClientCommand }: DogfightCallbacks) {
             },
         };
 
-        await client.init(client_callbacks, div, intl);
+        client.init(client_callbacks, div, intl);
     }
 
     useEffect(() => {

--- a/client/src/hooks/useGuest.ts
+++ b/client/src/hooks/useGuest.ts
@@ -19,8 +19,8 @@ export function useGuest(myName: string, clan: string) {
         },
     });
 
-    async function initialize(div: HTMLDivElement) {
-        await dogfight.initialize(div);
+    function initialize(div: HTMLDivElement) {
+        dogfight.initialize(div);
     }
 
     function sendChatMessage(message: string, global: boolean) {

--- a/client/src/hooks/useLocalHost.ts
+++ b/client/src/hooks/useLocalHost.ts
@@ -44,8 +44,8 @@ export function useLocalHost(gameMap: LevelName, recordGame: boolean, username: 
     // A collection of the connected users
     const dataConnections = useRef<Map<string, ConnectedPlayer>>(new Map());
 
-    async function initialize(div: HTMLDivElement) {
-        await dogfight.initialize(div);
+    function initialize(div: HTMLDivElement) {
+        dogfight.initialize(div);
     }
 
     function tickGame() {

--- a/client/src/hooks/useReplay.ts
+++ b/client/src/hooks/useReplay.ts
@@ -30,8 +30,8 @@ export function useReplay() {
         return true;
     }
 
-    async function initialize(div: HTMLDivElement) {
-        await dogfight.initialize(div);
+    function initialize(div: HTMLDivElement) {
+        dogfight.initialize(div);
     }
 
     function parseServerOutput(bytes: Uint8Array): ServerOutput[] {

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -6,16 +6,19 @@ import { MantineProvider } from "@mantine/core";
 import "@mantine/core/styles.css";
 import { HashRouter } from "react-router-dom";
 import { SettingsProvider } from "./contexts/settingsContext.tsx";
+import { TextureProvider } from "./contexts/textureContext.tsx";
 import { IntlProvider } from "./intl/IntlProvider.tsx";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
     <SettingsProvider>
         <IntlProvider>
-            <MantineProvider>
-                <HashRouter>
-                    <App />
-                </HashRouter>
-            </MantineProvider>
+            <TextureProvider>
+                <MantineProvider>
+                    <HashRouter>
+                        <App />
+                    </HashRouter>
+                </MantineProvider>
+            </TextureProvider>
         </IntlProvider>
     </SettingsProvider>,
 );

--- a/client/src/views/Replay.tsx
+++ b/client/src/views/Replay.tsx
@@ -30,15 +30,14 @@ export function Replay() {
                 const bytes = new Uint8Array(reader.result);
 
                 if (gameContainer.current) {
-                    initialize(gameContainer.current).then(() => {
-                        const didReadFile = loadReplay(bytes);
+                    initialize(gameContainer.current);
+                    const didReadFile = loadReplay(bytes);
 
-                        if (didReadFile) {
-                            setState(ReplayState.Watching);
-                        } else {
-                            setState(ReplayState.ProvideFile);
-                        }
-                    });
+                    if (didReadFile) {
+                        setState(ReplayState.Watching);
+                    } else {
+                        setState(ReplayState.ProvideFile);
+                    }
                 }
             }
         };


### PR DESCRIPTION
Each commit has its own responsibility, so reading commit by commit makes sense

- make entity collection code slightly more generic
  - we likely don't need Players in LevelEditor, so this change is ground work for that
  - in `DogFightClient` only store field `entities` which has them all
- load textures on site load
  - add simple react provider that ensures that pixi textures are in memory before going forward
-  make init code sync
   - as textures are already in memory, there is no need for promises in init code 
- move render only stuff to RenderClient to thin out `DogFightClient`
  
  Next up I'm looking to further modify the client code a bit so its easier to create different clients for different needs (i.e. one for game and one for level editor)