### PR TITLE
implement gameloop as single requestAnimationFrame loop

### DIFF
--- a/client/src/client/entities/backgroundItem.ts
+++ b/client/src/client/entities/backgroundItem.ts
@@ -4,6 +4,7 @@ import * as PIXI from "pixi.js";
 import { DrawLayer } from "../constants";
 import { Textures } from "../textures";
 import { Entity, EntityUpdateCallbacks } from "./entity";
+import { animationRunner } from "../../gameLoop";
 
 type FlagTypes = "FlagAllies" | "FlagCentrals";
 
@@ -24,7 +25,6 @@ export class BackgroundItem implements Entity<BackgroundItemProperties> {
 
     private itemTextures: Record<BackgroundItemType, PIXI.Texture>;
     private flagTypes: BackgroundItemType[];
-    private flagInterval: number | null = null;
     private flagTextures: FlagTextureMap;
     private flagIndex = 0;
 
@@ -66,20 +66,21 @@ export class BackgroundItem implements Entity<BackgroundItemProperties> {
         return this.container;
     }
 
+    private animate = () => {
+        this.waveFlag();
+    };
+
     public updateCallbacks: EntityUpdateCallbacks<BackgroundItemProperties> = {
         bg_item_type: () => {
             const { bg_item_type } = this.props;
             if (bg_item_type === undefined) return;
             if (!this.props.bg_item_type) return;
-            if (this.flagInterval !== null) {
-                clearInterval(this.flagInterval);
-            }
 
             const texture = this.itemTextures[bg_item_type];
             this.itemSprite.texture = texture;
 
             if (this.flagTypes.includes(bg_item_type)) {
-                this.flagInterval = window.setInterval(() => this.waveFlag(), 100);
+                animationRunner.registerAnimation(this.animate, 10);
             }
         },
         facing: () => {
@@ -118,8 +119,6 @@ export class BackgroundItem implements Entity<BackgroundItemProperties> {
     }
 
     public destroy() {
-        if (this.flagInterval !== null) {
-            clearInterval(this.flagInterval);
-        }
+        animationRunner.unregisterAnimation(this.animate);
     }
 }

--- a/client/src/client/entities/bullet.ts
+++ b/client/src/client/entities/bullet.ts
@@ -1,10 +1,11 @@
-import { Entity, EntityUpdateCallbacks } from "./entity";
-import * as PIXI from "pixi.js";
-import { Howl } from "howler";
 import { BulletProperties } from "dogfight-types/BulletProperties";
-import { directionToRadians } from "../helpers";
+import { Howl } from "howler";
+import * as PIXI from "pixi.js";
+import { animationRunner } from "../../gameLoop";
 import { DrawLayer } from "../constants";
+import { directionToRadians } from "../helpers";
 import { soundManager } from "../soundManager";
+import { Entity, EntityUpdateCallbacks } from "./entity";
 
 const COLORS: string[] = ["#000000", "#171717", "#515151", "#606060", "#999999"];
 
@@ -14,7 +15,6 @@ export class Bullet implements Entity<BulletProperties> {
 
     private sound: Howl;
     private age = 1;
-    private bullet_interval: number;
 
     public isGameRunning: boolean = true;
 
@@ -23,6 +23,12 @@ export class Bullet implements Entity<BulletProperties> {
         client_y: 0,
         speed: 0,
         direction: 0,
+    };
+
+    private animate = () => {
+        if (this.isGameRunning) {
+            this.move_bullet();
+        }
     };
 
     constructor() {
@@ -47,11 +53,7 @@ export class Bullet implements Entity<BulletProperties> {
 
         this.container.zIndex = DrawLayer.Bullet;
 
-        this.bullet_interval = window.setInterval(() => {
-            if (this.isGameRunning) {
-                this.move_bullet();
-            }
-        }, 10);
+        animationRunner.registerAnimation(this.animate, 1);
     }
 
     private move_bullet() {
@@ -100,6 +102,6 @@ export class Bullet implements Entity<BulletProperties> {
 
     public destroy() {
         this.sound.stop();
-        window.clearInterval(this.bullet_interval);
+        animationRunner.unregisterAnimation(this.animate);
     }
 }

--- a/client/src/client/entities/man.ts
+++ b/client/src/client/entities/man.ts
@@ -6,6 +6,7 @@ import { ManProperties } from "dogfight-types/ManProperties";
 import { Stats } from "../hud";
 import { RadarObject, RadarObjectType } from "../radar";
 import { Team } from "dogfight-types/Team";
+import { animationRunner } from "../../gameLoop";
 
 export class Man implements Entity<ManProperties>, Followable, RadarEnabled {
     public props: Required<ManProperties> = {
@@ -19,10 +20,13 @@ export class Man implements Entity<ManProperties>, Followable, RadarEnabled {
     private manContainer: PIXI.Container;
 
     private manSprite: PIXI.Sprite;
-    private walkAnim: number | null = null;
 
     private nameText: PIXI.Text;
     private frameCount = 0;
+
+    private animate = () => {
+        this.animateWalk();
+    };
 
     constructor() {
         this.container = new PIXI.Container();
@@ -49,7 +53,7 @@ export class Man implements Entity<ManProperties>, Followable, RadarEnabled {
 
         this.container.zIndex = DrawLayer.Man;
 
-        this.walkAnim = window.setInterval(() => this.animateWalk(), 100);
+        animationRunner.registerAnimation(this.animate, 10);
     }
 
     public callbackOrder: (keyof ManProperties)[] = ["client_x", "client_y"];
@@ -81,7 +85,7 @@ export class Man implements Entity<ManProperties>, Followable, RadarEnabled {
     }
 
     public destroy() {
-        if (this.walkAnim) window.clearInterval(this.walkAnim);
+        animationRunner.unregisterAnimation(this.animate);
     }
 
     private updateX(): void {

--- a/client/src/client/entities/plane.ts
+++ b/client/src/client/entities/plane.ts
@@ -1,14 +1,15 @@
-import { Entity, EntityUpdateCallbacks, Followable, Point, RadarEnabled } from "./entity";
-import * as PIXI from "pixi.js";
 import { PlaneProperties } from "dogfight-types/PlaneProperties";
 import { PlaneType } from "dogfight-types/PlaneType";
-import { Textures } from "../textures";
-import { directionToRadians } from "../helpers";
+import { Team } from "dogfight-types/Team";
+import * as PIXI from "pixi.js";
+import { animationRunner } from "../../gameLoop";
 import { DrawLayer, TeamColor } from "../constants";
+import { directionToRadians } from "../helpers";
 import { Stats } from "../hud";
 import { RadarObject, RadarObjectType } from "../radar";
-import { Team } from "dogfight-types/Team";
 import { soundManager } from "../soundManager";
+import { Textures } from "../textures";
+import { Entity, EntityUpdateCallbacks, Followable, Point, RadarEnabled } from "./entity";
 
 const PLANE_TEXTURE_ID: Record<PlaneType, number> = {
     Albatros: 4,
@@ -19,7 +20,6 @@ const PLANE_TEXTURE_ID: Record<PlaneType, number> = {
     Sopwith: 9,
 };
 
-const GRAY_SMOKE_INTERVAL_MS = 100;
 const GRAY_SMOKE_LIFETIME_MS = 300;
 
 const BLACK_SMOKE_LIFETIME_MS = 300;
@@ -31,7 +31,6 @@ export class Plane implements Entity<PlaneProperties>, Followable, RadarEnabled 
     private planeSprite: PIXI.Sprite;
     private first_flip: boolean = true;
     private frame = 0;
-    private animation_gray_smoke: number;
     private dark_smoke_timeout: number;
     private darkSmoke: PIXI.Container;
     private angle: number = 0;
@@ -49,6 +48,32 @@ export class Plane implements Entity<PlaneProperties>, Followable, RadarEnabled 
         total_bombs: 0,
         client_ammo: 0,
         client_health: 0,
+    };
+
+    private animate = () => {
+        if (!this.props.motor_on || this.props.mode !== "Flying") return;
+
+        const tex = this.getTexture();
+        const w = tex.width;
+        const h = tex.height;
+        const d1 = this.angle;
+
+        const x = this.planeContainer.position.x;
+        const y = this.planeContainer.position.y;
+        //console.log(this.planeSprite.position)
+
+        const k = Math.floor(x - Math.cos(d1) * (w / 2 + 6));
+        const m = Math.floor(y - Math.sin(d1) * (h / 2 + 6));
+
+        const smoke = new PIXI.Sprite(Textures["smoke1.gif"]);
+        smoke.anchor.set(0.5);
+        smoke.position.set(k, m);
+        //console.log(k, m)
+        this.container.addChild(smoke);
+
+        window.setTimeout(() => {
+            this.container.removeChild(smoke);
+        }, GRAY_SMOKE_LIFETIME_MS);
     };
 
     constructor() {
@@ -80,31 +105,7 @@ export class Plane implements Entity<PlaneProperties>, Followable, RadarEnabled 
             this.createDarkSmoke();
         });
 
-        this.animation_gray_smoke = window.setInterval(() => {
-            if (!this.props.motor_on || this.props.mode !== "Flying") return;
-
-            const tex = this.getTexture();
-            const w = tex.width;
-            const h = tex.height;
-            const d1 = this.angle;
-
-            const x = this.planeContainer.position.x;
-            const y = this.planeContainer.position.y;
-            //console.log(this.planeSprite.position)
-
-            const k = Math.floor(x - Math.cos(d1) * (w / 2 + 6));
-            const m = Math.floor(y - Math.sin(d1) * (h / 2 + 6));
-
-            const smoke = new PIXI.Sprite(Textures["smoke1.gif"]);
-            smoke.anchor.set(0.5);
-            smoke.position.set(k, m);
-            //console.log(k, m)
-            this.container.addChild(smoke);
-
-            window.setTimeout(() => {
-                this.container.removeChild(smoke);
-            }, GRAY_SMOKE_LIFETIME_MS);
-        }, GRAY_SMOKE_INTERVAL_MS);
+        animationRunner.registerAnimation(this.animate, 10);
     }
 
     private createDarkSmoke(): void {
@@ -262,7 +263,7 @@ export class Plane implements Entity<PlaneProperties>, Followable, RadarEnabled 
     };
 
     public destroy() {
-        window.clearInterval(this.animation_gray_smoke);
+        animationRunner.unregisterAnimation(this.animate);
         window.clearTimeout(this.dark_smoke_timeout);
         if (this.props.motor_on) soundManager.handlePlayMotorSound(false);
     }

--- a/client/src/client/entities/plane.ts
+++ b/client/src/client/entities/plane.ts
@@ -60,7 +60,6 @@ export class Plane implements Entity<PlaneProperties>, Followable, RadarEnabled 
 
         const x = this.planeContainer.position.x;
         const y = this.planeContainer.position.y;
-        //console.log(this.planeSprite.position)
 
         const k = Math.floor(x - Math.cos(d1) * (w / 2 + 6));
         const m = Math.floor(y - Math.sin(d1) * (h / 2 + 6));
@@ -68,7 +67,6 @@ export class Plane implements Entity<PlaneProperties>, Followable, RadarEnabled 
         const smoke = new PIXI.Sprite(Textures["smoke1.gif"]);
         smoke.anchor.set(0.5);
         smoke.position.set(k, m);
-        //console.log(k, m)
         this.container.addChild(smoke);
 
         window.setTimeout(() => {
@@ -215,9 +213,7 @@ export class Plane implements Entity<PlaneProperties>, Followable, RadarEnabled 
         team: () => {},
         client_ammo: () => {},
         client_health: () => {},
-        client_fuel: () => {
-            //console.log("fuel", this.props.client_fuel)
-        },
+        client_fuel: () => {},
 
         total_bombs: () => {
             console.log("Bombs", this.props.total_bombs);
@@ -236,10 +232,7 @@ export class Plane implements Entity<PlaneProperties>, Followable, RadarEnabled 
             if (do_flip) {
                 this.frame = 0;
                 this.renderFrame();
-                //console.log(this.frame)
             }
-
-            //console.log("flipped", this.props.flipped)
         },
 
         mode: () => {
@@ -256,7 +249,6 @@ export class Plane implements Entity<PlaneProperties>, Followable, RadarEnabled 
         },
 
         direction: () => {
-            // console.log(this.props.direction)
             this.angle = directionToRadians(this.props.direction);
             this.planeSprite.rotation = this.angle;
         },
@@ -278,7 +270,6 @@ export class Plane implements Entity<PlaneProperties>, Followable, RadarEnabled 
     }
 
     public setPlayerName(name: string | null, pov_team: Team | null) {
-        // console.log("set player name", name, pov_team)
         if (!name) {
             this.nameText.visible = false;
             return;

--- a/client/src/client/entities/water.ts
+++ b/client/src/client/entities/water.ts
@@ -3,6 +3,7 @@ import * as PIXI from "pixi.js";
 import { DrawLayer, TERRAIN_WATER_COLOR } from "../constants";
 import { Textures } from "../textures";
 import { Entity, EntityUpdateCallbacks } from "./entity";
+import { animationRunner } from "../../gameLoop";
 
 export class Water implements Entity<WaterProperties> {
     public props: Required<WaterProperties> = {
@@ -17,7 +18,10 @@ export class Water implements Entity<WaterProperties> {
     private waves: PIXI.TilingSprite;
 
     private waveIndex = 0;
-    private waveInterval: number;
+
+    private animate = () => {
+        this.waveStep();
+    };
 
     constructor() {
         this.container = new PIXI.Container();
@@ -27,9 +31,7 @@ export class Water implements Entity<WaterProperties> {
         this.waves = new PIXI.TilingSprite(wave1);
         this.waves.height = wave1.height;
 
-        this.waveInterval = window.setInterval(() => {
-            this.waveStep();
-        }, 200);
+        animationRunner.registerAnimation(this.animate, 20);
 
         this.container.addChild(this.waterGraphics);
         this.container.addChild(this.waves);
@@ -100,6 +102,6 @@ export class Water implements Entity<WaterProperties> {
     }
 
     public destroy() {
-        window.clearInterval(this.waveInterval);
+        animationRunner.unregisterAnimation(this.animate);
     }
 }

--- a/client/src/gameLoop.ts
+++ b/client/src/gameLoop.ts
@@ -1,6 +1,9 @@
 type UpdateFn = (currentTick: number) => void;
 const noop = () => {};
 
+/**
+ * When facing a case where useInterval seems handy, use this GameLoop instead
+ */
 class GameLoop {
     private currentTick: number = 0;
     private lastTime: number = performance.now();
@@ -18,6 +21,11 @@ class GameLoop {
         return this;
     }
 
+    /**
+     * Function that handles updating the engine ticks
+     * This needs to be called when hosting a game,
+     * this should not be called when joining a game
+     */
     public setHostEngineUpdateFn(updateFn: UpdateFn) {
         this.updateFn = updateFn;
         return this;
@@ -51,11 +59,13 @@ class GameLoop {
     }
 
     public start() {
+        this.currentTick = 0;
+        console.log("starting game loop");
         if (this.requestId) return;
         this.startLoop();
     }
 
-    public pause() {
+    public stop() {
         this.pauseLoop();
     }
 

--- a/client/src/gameLoop.ts
+++ b/client/src/gameLoop.ts
@@ -60,7 +60,7 @@ class GameLoop {
 
     public start() {
         this.currentTick = 0;
-        console.log("starting game loop");
+
         if (this.requestId) return;
         this.startLoop();
     }

--- a/client/src/gameLoop.ts
+++ b/client/src/gameLoop.ts
@@ -1,0 +1,94 @@
+type UpdateFn = (currentTick: number) => void;
+const noop = () => {};
+
+class GameLoop {
+    private currentTick: number = 0;
+    private lastTime: number = performance.now();
+    private requestId: number | null = null;
+    private tickInterval: number = -1;
+    private updateFn: UpdateFn = noop;
+    private animationRunner: AnimationRunner;
+
+    constructor(animationRunner: AnimationRunner) {
+        this.animationRunner = animationRunner;
+    }
+
+    public setTickInterval(tickInterval: number) {
+        this.tickInterval = tickInterval;
+        return this;
+    }
+
+    public setHostEngineUpdateFn(updateFn: UpdateFn) {
+        this.updateFn = updateFn;
+        return this;
+    }
+
+    private gameLoop = (time: number) => {
+        let delta = time - this.lastTime;
+
+        while (delta >= this.tickInterval) {
+            this.currentTick++;
+            delta -= this.tickInterval;
+            this.updateFn(this.currentTick);
+            this.animationRunner.runAnimations(this.currentTick);
+        }
+
+        this.lastTime = time - delta;
+
+        this.requestId = requestAnimationFrame(this.gameLoop);
+    };
+
+    private startLoop() {
+        if (this.requestId) return;
+        this.lastTime = performance.now();
+        this.requestId = requestAnimationFrame(this.gameLoop);
+    }
+
+    private pauseLoop() {
+        if (!this.requestId) return;
+        cancelAnimationFrame(this.requestId);
+        this.requestId = null;
+    }
+
+    public start() {
+        if (this.requestId) return;
+        this.startLoop();
+    }
+
+    public pause() {
+        this.pauseLoop();
+    }
+
+    public isRunning() {
+        return this.requestId !== null;
+    }
+}
+
+class AnimationRunner {
+    private animations: Map<UpdateFn, number> = new Map();
+    private nextExecutionTicks: Map<UpdateFn, number> = new Map();
+
+    /**
+     * @param animation some fn that does animations manually
+     * @param tickInterval how many game ticks should be between each animation tick
+     */
+    registerAnimation(animation: UpdateFn, tickInterval: number) {
+        this.animations.set(animation, tickInterval);
+    }
+
+    unregisterAnimation(animation: UpdateFn) {
+        this.animations.delete(animation);
+    }
+
+    runAnimations(currentTick: number) {
+        for (const [animate, tickInterval] of this.animations.entries()) {
+            if (currentTick >= (this.nextExecutionTicks.get(animate) ?? 0)) {
+                animate(currentTick);
+                this.nextExecutionTicks.set(animate, currentTick + tickInterval);
+            }
+        }
+    }
+}
+
+export const animationRunner = new AnimationRunner();
+export const gameLoop = new GameLoop(animationRunner).setTickInterval(10);

--- a/client/src/hooks/useGuest.ts
+++ b/client/src/hooks/useGuest.ts
@@ -86,7 +86,7 @@ export function useGuest(myName: string, clan: string) {
             console.log("destroy guest");
             peer.current?.removeAllListeners();
             peer.current?.destroy();
-            gameLoop.pause();
+            gameLoop.stop();
         };
     }, []);
 

--- a/client/src/hooks/useGuest.ts
+++ b/client/src/hooks/useGuest.ts
@@ -2,6 +2,7 @@ import { PlayerCommand } from "dogfight-types/PlayerCommand";
 import { ServerOutput } from "dogfight-types/ServerOutput";
 import Peer from "peerjs";
 import { useEffect, useRef } from "react";
+import { gameLoop } from "../gameLoop";
 import { useDogfight } from "./useDogfight";
 import { PeerJSPath } from "./useLocalHost";
 
@@ -21,6 +22,7 @@ export function useGuest(myName: string, clan: string) {
 
     function initialize(div: HTMLDivElement) {
         dogfight.initialize(div);
+        gameLoop.start();
     }
 
     function sendChatMessage(message: string, global: boolean) {
@@ -57,6 +59,7 @@ export function useGuest(myName: string, clan: string) {
                 conn.send(cmd);
 
                 conn.on("data", (data) => {
+                    console.log(data);
                     if (typeof data === "string") {
                         const output: ServerOutput = JSON.parse(data);
                         dogfight.handleGameEvents([output]);
@@ -83,6 +86,7 @@ export function useGuest(myName: string, clan: string) {
             console.log("destroy guest");
             peer.current?.removeAllListeners();
             peer.current?.destroy();
+            gameLoop.pause();
         };
     }, []);
 

--- a/client/src/hooks/useGuest.ts
+++ b/client/src/hooks/useGuest.ts
@@ -59,7 +59,6 @@ export function useGuest(myName: string, clan: string) {
                 conn.send(cmd);
 
                 conn.on("data", (data) => {
-                    console.log(data);
                     if (typeof data === "string") {
                         const output: ServerOutput = JSON.parse(data);
                         dogfight.handleGameEvents([output]);

--- a/client/src/hooks/useLocalHost.ts
+++ b/client/src/hooks/useLocalHost.ts
@@ -7,8 +7,8 @@ import { useDogfight } from "./useDogfight";
 
 import { LevelName } from "src/views/Lobby";
 import Levels from "../assets/levels.json";
-import { randomGuid } from "../helpers";
 import { gameLoop } from "../gameLoop";
+import { randomGuid } from "../helpers";
 
 type ConnectedPlayer = {
     player_guid: string;
@@ -175,7 +175,7 @@ export function useLocalHost(gameMap: LevelName, recordGame: boolean, username: 
     useEffect(() => {
         return () => {
             console.log("destroy host");
-            gameLoop.pause();
+            gameLoop.stop();
             peer.current?.removeAllListeners();
             peer.current?.destroy();
         };

--- a/client/src/hooks/useLocalHost.ts
+++ b/client/src/hooks/useLocalHost.ts
@@ -8,6 +8,7 @@ import { useDogfight } from "./useDogfight";
 import { LevelName } from "src/views/Lobby";
 import Levels from "../assets/levels.json";
 import { randomGuid } from "../helpers";
+import { gameLoop } from "../gameLoop";
 
 type ConnectedPlayer = {
     player_guid: string;
@@ -34,13 +35,6 @@ export function useLocalHost(gameMap: LevelName, recordGame: boolean, username: 
     // Lobby state
     const [roomCode, setRoomCode] = useState<string | null>(null);
 
-    // Game Tick State
-    const tickInterval = useRef<number | null>(null);
-    const paused = useRef<boolean>(false);
-    const tickCounter = useRef(0);
-    // When set to true, this advances the game one tick
-    const doTick = useRef(false);
-
     // A collection of the connected users
     const dataConnections = useRef<Map<string, ConnectedPlayer>>(new Map());
 
@@ -48,16 +42,12 @@ export function useLocalHost(gameMap: LevelName, recordGame: boolean, username: 
         dogfight.initialize(div);
     }
 
-    function tickGame() {
-        if (paused.current && !doTick.current) return;
-        doTick.current = false;
-        tickCounter.current++;
-        const allCommands = clearPlayerCommands(tickCounter.current);
+    function tickGame(currentTick: number) {
+        const allCommands = clearPlayerCommands(currentTick);
         const input_json = JSON.stringify(allCommands);
-        //const start = performance.now();
         dogfight.engine.tick(input_json);
 
-        if (tickCounter.current % 2 == 0) {
+        if (currentTick % 2 == 0) {
             const changed_state = dogfight.engine.flush_changed_state();
             // If data channel is open, send updates.
             const events_json = dogfight.engine.game_events_from_binary(changed_state);
@@ -66,10 +56,8 @@ export function useLocalHost(gameMap: LevelName, recordGame: boolean, username: 
             // Don't send things off unless there's something to send off.
             if (!events.length) return;
 
-            //console.log(changed_state)
             // Send out events to every connection
             for (const [_, dataConnection] of dataConnections.current) {
-                //localDataChannel.current?.send(changed_state)
                 dataConnection.connection.send(changed_state);
             }
 
@@ -105,7 +93,7 @@ export function useLocalHost(gameMap: LevelName, recordGame: boolean, username: 
             });
 
             // Set up function to begin ticking the game
-            tickInterval.current = window.setInterval(() => tickGame(), 1000 / 100);
+            gameLoop.setHostEngineUpdateFn(tickGame).start();
         });
 
         peer.current.on("connection", (conn) => {
@@ -187,7 +175,7 @@ export function useLocalHost(gameMap: LevelName, recordGame: boolean, username: 
     useEffect(() => {
         return () => {
             console.log("destroy host");
-            if (tickInterval.current) window.clearInterval(tickInterval.current);
+            gameLoop.pause();
             peer.current?.removeAllListeners();
             peer.current?.destroy();
         };

--- a/client/src/hooks/useReplay.ts
+++ b/client/src/hooks/useReplay.ts
@@ -87,7 +87,7 @@ export function useReplay() {
 
     useEffect(() => {
         return () => {
-            gameLoop.pause();
+            gameLoop.stop();
         };
     }, []);
 

--- a/client/src/hooks/useReplay.ts
+++ b/client/src/hooks/useReplay.ts
@@ -1,7 +1,8 @@
 import { ReplayFile } from "dogfight-types/ReplayFile";
 import { ServerInput } from "dogfight-types/ServerInput";
 import { ServerOutput } from "dogfight-types/ServerOutput";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
+import { gameLoop } from "../gameLoop";
 import { useDogfight } from "./useDogfight";
 
 export function useReplay() {
@@ -14,8 +15,6 @@ export function useReplay() {
 
     const [replayFile, setReplayFile] = useState<ReplayFile | null>(null);
     const [spectating, setSpectating] = useState<string | null>(null);
-    const tickInterval = useRef<number | null>(null);
-    const tick = useRef(0);
 
     function loadReplay(binary: Uint8Array): boolean {
         const replay_string = dogfight.engine.replay_file_binary_to_json(binary);
@@ -44,13 +43,10 @@ export function useReplay() {
         console.log("REPLAY FILE CHANGED");
         if (!replayFile) return;
 
-        tick.current = 0;
         dogfight.engine.load_level(replayFile.level_data);
 
-        tickInterval.current = window.setInterval(() => {
-            //console.log(tick.current)
-            const tickData = replayFile.ticks.find((x) => x.tick_number === tick.current);
-            tick.current++;
+        const updateFn = (currentTick: number) => {
+            const tickData = replayFile.ticks.find((x) => x.tick_number === currentTick);
 
             let input: ServerInput[] = [];
             if (tickData) {
@@ -84,12 +80,14 @@ export function useReplay() {
             const changed_state = dogfight.engine.flush_changed_state();
             const events = parseServerOutput(changed_state);
             dogfight.handleGameEvents(events);
-        }, 1000 / 100);
+        };
+
+        gameLoop.setHostEngineUpdateFn(updateFn).start();
     }, [replayFile]);
 
     useEffect(() => {
         return () => {
-            if (tickInterval.current) window.clearInterval(tickInterval.current);
+            gameLoop.pause();
         };
     }, []);
 


### PR DESCRIPTION
closes https://github.com/mattbruv/Lentokonepeli/issues/22

Okay, reopened this and tested a bunch (on firefox & chrome). Feels good, feel free to try this out yourself.

So in essence, this replaces all `setInterval` loops which are _not accurate_ with a single `requestAnimationFrame` loop & delta tracking.

With delta tracking meaning here that if there is more than 1 tick worth of time between two game loop frames, all missed frames are computed and played retroactively.