### PR TITLE
Improve replay system

### DIFF
--- a/client/src/client/DogfightClient.ts
+++ b/client/src/client/DogfightClient.ts
@@ -169,12 +169,12 @@ export class DogfightClient {
         });
     }
 
-    public setMyPlayerGuid(guid: string) {
-        console.log("MY GUID", guid);
+    public setMyPlayerGuid(guid: string | null) {
         this.myPlayerGuid = guid;
         const myPlayer = this.entities.Player.collection.entries().find((x) => x[1].props.guid === guid);
+        this.myPlayerId = myPlayer?.[0] ?? null;
         if (myPlayer) {
-            this.myPlayerId = myPlayer[0];
+            this.onMyPlayerUpdate(myPlayer[1].props);
         }
     }
 

--- a/client/src/client/DogfightClient.ts
+++ b/client/src/client/DogfightClient.ts
@@ -328,7 +328,7 @@ export class DogfightClient {
                     break;
                 }
                 case "ChatMessage": {
-                    this.callbacks?.onMessage(event.data);
+                    this.callbacks?.onMessage(event.data[1]);
                     break;
                 }
                 default: {

--- a/client/src/client/DogfightClient.ts
+++ b/client/src/client/DogfightClient.ts
@@ -172,6 +172,10 @@ export class DogfightClient {
     public setMyPlayerGuid(guid: string) {
         console.log("MY GUID", guid);
         this.myPlayerGuid = guid;
+        const myPlayer = this.entities.Player.collection.entries().find((x) => x[1].props.guid === guid);
+        if (myPlayer) {
+            this.myPlayerId = myPlayer[0];
+        }
     }
 
     public setMyPlayerId(id: number) {

--- a/client/src/client/DogfightClient.ts
+++ b/client/src/client/DogfightClient.ts
@@ -170,6 +170,7 @@ export class DogfightClient {
     }
 
     public setMyPlayerGuid(guid: string | null, replay: boolean) {
+        console.log("My guid:", guid);
         this.myPlayerGuid = guid;
         const myPlayer = this.entities.Player.collection.entries().find((x) => x[1].props.guid === guid);
         this.myPlayerId = myPlayer?.[0] ?? null;
@@ -179,10 +180,6 @@ export class DogfightClient {
             }
             this.onJoinTeam(myPlayer?.[1].props.team ?? "Allies");
         }
-    }
-
-    public setMyPlayerId(id: number) {
-        this.myPlayerId = id;
     }
 
     private onJoinTeam(team: Team) {

--- a/client/src/client/DogfightClient.ts
+++ b/client/src/client/DogfightClient.ts
@@ -158,6 +158,12 @@ export class DogfightClient {
         this.centerCamera(0, 0);
     }
 
+    public clearEntities() {
+        destroyEntities(this.entities, {
+            onRemove: this.onEntityRemoved.bind(this),
+        });
+    }
+
     public destroy() {
         console.log("destroying client...");
         destroyEntities(this.entities, {

--- a/client/src/client/DogfightClient.ts
+++ b/client/src/client/DogfightClient.ts
@@ -176,6 +176,7 @@ export class DogfightClient {
         if (myPlayer) {
             this.onMyPlayerUpdate(myPlayer[1].props);
         }
+        this.onJoinTeam(myPlayer?.[1].props.team ?? "Allies");
     }
 
     public setMyPlayerId(id: number) {

--- a/client/src/client/DogfightClient.ts
+++ b/client/src/client/DogfightClient.ts
@@ -169,14 +169,16 @@ export class DogfightClient {
         });
     }
 
-    public setMyPlayerGuid(guid: string | null) {
+    public setMyPlayerGuid(guid: string | null, replay: boolean) {
         this.myPlayerGuid = guid;
         const myPlayer = this.entities.Player.collection.entries().find((x) => x[1].props.guid === guid);
         this.myPlayerId = myPlayer?.[0] ?? null;
-        if (myPlayer) {
-            this.onMyPlayerUpdate(myPlayer[1].props);
+        if (replay) {
+            if (myPlayer) {
+                this.onMyPlayerUpdate(myPlayer[1].props);
+            }
+            this.onJoinTeam(myPlayer?.[1].props.team ?? "Allies");
         }
-        this.onJoinTeam(myPlayer?.[1].props.team ?? "Allies");
     }
 
     public setMyPlayerId(id: number) {
@@ -319,7 +321,7 @@ export class DogfightClient {
                 }
                 case "YourPlayerGuid": {
                     this.sendPlayerUpdate = true;
-                    this.setMyPlayerGuid(event.data);
+                    this.setMyPlayerGuid(event.data, false);
                     break;
                 }
                 case "ChatMessage": {

--- a/client/src/components/ReplayControls.tsx
+++ b/client/src/components/ReplayControls.tsx
@@ -1,0 +1,57 @@
+import { ComboboxItem, Select, Stack } from "@mantine/core";
+import { PlayerGuid } from "dogfight-types/PlayerGuid";
+import { ReplayEvent } from "dogfight-types/ReplayEvent";
+import { useMemo } from "react";
+import { ReplayTimer } from "./ReplayTimer";
+
+type ReplayControlsProps = {
+    // slider props
+    currentTick: number;
+    maxTicks: number;
+    onScrub?: (tick: number) => void;
+
+    // other props
+    events: ReplayEvent[];
+    players: Record<PlayerGuid, string>;
+
+    spectating: string | null;
+    setSpectating: (guid: string | null) => void;
+};
+
+export function ReplayControls({
+    currentTick,
+    maxTicks,
+    onScrub,
+    events,
+    players,
+    spectating,
+    setSpectating,
+}: ReplayControlsProps) {
+    const watchPlayers: ComboboxItem[] = useMemo(() => {
+        return Object.entries(players).map(([guid, name]): ComboboxItem => {
+            return {
+                label: name,
+                value: guid,
+            };
+        });
+    }, [players]);
+
+    const playerEvents = useMemo(() => {
+        return 3;
+    }, [events]);
+
+    return (
+        <Stack>
+            <ReplayTimer currentTick={currentTick} maxTicks={maxTicks} onScrub={onScrub} />
+            <div>
+                <Select
+                    label="Spectating Player"
+                    placeholder="Pick a player..."
+                    value={spectating}
+                    onChange={setSpectating}
+                    data={watchPlayers}
+                />
+            </div>
+        </Stack>
+    );
+}

--- a/client/src/components/ReplayControls.tsx
+++ b/client/src/components/ReplayControls.tsx
@@ -82,7 +82,7 @@ export function ReplayControls({
                     <ScrollArea h={400}>
                         {playerEvents.map((event, i) => (
                             <div key={i}>
-                                {event.event.type}
+                                <Text c={event.tick < currentTick ? "dimmed" : ""}>{event.event.type}</Text>
                                 <Text size="xs" c={"dimmed"}>
                                     {ticksToHHMMSS(event.tick)}
                                 </Text>

--- a/client/src/components/ReplayControls.tsx
+++ b/client/src/components/ReplayControls.tsx
@@ -25,6 +25,7 @@ const EVENT_NAMES: Record<ReplayEventType["type"], string> = {
     AbandonedPlane: "🪂 Abandoned",
     Downed: "💢 Downed",
     DownedBy: "☠️ Downed By",
+    ChatMessage: "💬 Chat",
 };
 
 export function ReplayControls({ summary, callbacks, events, players, info }: ReplayControlsProps) {
@@ -47,10 +48,11 @@ export function ReplayControls({ summary, callbacks, events, players, info }: Re
         return events.filter((x) => x.player === info.spectating).filter((x) => viewEvents.includes(x.event.type));
     }, [info.spectating, events, viewEvents]);
 
-    const lookupName = useCallback(
+    const eventText = useCallback(
         (event: ReplayEvent): string | null => {
             if ("data" in event.event) {
-                return players[event.event.data];
+                if (event.event.type !== "ChatMessage") return " " + players[event.event.data];
+                else return ": " + event.event.data.message;
             }
             return null;
         },
@@ -83,7 +85,8 @@ export function ReplayControls({ summary, callbacks, events, players, info }: Re
                         {playerEvents.map((event, i) => (
                             <div key={i}>
                                 <Text c={event.tick < info.tick ? "dimmed" : ""}>
-                                    {EVENT_NAMES[event.event.type]} {lookupName(event)}
+                                    {EVENT_NAMES[event.event.type]}
+                                    {eventText(event)}
                                 </Text>
                                 <Text size="xs" c={"dimmed"}>
                                     {ticksToHHMMSS(event.tick)}

--- a/client/src/components/ReplayControls.tsx
+++ b/client/src/components/ReplayControls.tsx
@@ -2,7 +2,7 @@ import { ComboboxItem, MultiSelect, ScrollArea, Select, Stack, Text } from "@man
 import { PlayerGuid } from "dogfight-types/PlayerGuid";
 import { ReplayEvent } from "dogfight-types/ReplayEvent";
 import { ReplayEventType } from "dogfight-types/ReplayEventType";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { ticksToHHMMSS } from "../helpers";
 import { ReplayTimer } from "./ReplayTimer";
 
@@ -57,6 +57,16 @@ export function ReplayControls({
         return events.filter((x) => x.player === spectating).filter((x) => viewEvents.includes(x.event.type));
     }, [spectating, events, viewEvents]);
 
+    const lookupName = useCallback(
+        (event: ReplayEvent): string | null => {
+            if ("data" in event.event) {
+                return players[event.event.data];
+            }
+            return null;
+        },
+        [players],
+    );
+
     const eventOptions: ComboboxItem[] = useMemo(() => {
         return Object.entries(EVENT_NAMES).map(([event_type, label]): ComboboxItem => {
             return {
@@ -82,7 +92,9 @@ export function ReplayControls({
                     <ScrollArea h={400}>
                         {playerEvents.map((event, i) => (
                             <div key={i}>
-                                <Text c={event.tick < currentTick ? "dimmed" : ""}>{event.event.type}</Text>
+                                <Text c={event.tick < currentTick ? "dimmed" : ""}>
+                                    {EVENT_NAMES[event.event.type]} {lookupName(event)}
+                                </Text>
                                 <Text size="xs" c={"dimmed"}>
                                     {ticksToHHMMSS(event.tick)}
                                 </Text>

--- a/client/src/components/ReplayControls.tsx
+++ b/client/src/components/ReplayControls.tsx
@@ -1,4 +1,4 @@
-import { ComboboxItem, MultiSelect, ScrollArea, Select, Stack, Text } from "@mantine/core";
+import { Button, ComboboxItem, MultiSelect, ScrollArea, Select, Stack, Text } from "@mantine/core";
 import { PlayerGuid } from "dogfight-types/PlayerGuid";
 import { ReplayEvent } from "dogfight-types/ReplayEvent";
 import { ReplayEventType } from "dogfight-types/ReplayEventType";
@@ -98,6 +98,7 @@ export function ReplayControls({
                                 <Text size="xs" c={"dimmed"}>
                                     {ticksToHHMMSS(event.tick)}
                                 </Text>
+                                {onScrub ? <Button onClick={(e) => onScrub(event.tick - 100 * 5)}>👀</Button> : null}
                             </div>
                         ))}
                     </ScrollArea>

--- a/client/src/components/ReplayTimer.tsx
+++ b/client/src/components/ReplayTimer.tsx
@@ -1,0 +1,44 @@
+import { Group, Slider, Text } from "@mantine/core";
+import { useEffect, useState } from "react";
+import { ticksToHHMMSS } from "../helpers";
+
+type ReplayTimerProps = {
+    currentTick: number;
+    maxTicks: number;
+    onScrub?: (tick: number) => void;
+};
+
+export function ReplayTimer({ currentTick, maxTicks, onScrub }: ReplayTimerProps) {
+    const [scrubTick, setScrubTick] = useState(currentTick);
+    const [isScrubbing, setIsScrubbing] = useState(false);
+
+    useEffect(() => {
+        if (!isScrubbing) setScrubTick(currentTick);
+    }, [currentTick, isScrubbing]);
+
+    return (
+        <div>
+            <Slider
+                value={scrubTick}
+                min={0}
+                max={maxTicks}
+                step={1}
+                onChange={setScrubTick}
+                onChangeEnd={(value) => {
+                    setIsScrubbing(false);
+                    onScrub?.(value);
+                }}
+                onPointerDown={() => setIsScrubbing(true)}
+                styles={{ thumb: { width: 12, height: 12 } }}
+            />
+            <Group justify="space-between" mt={4}>
+                <Text size="xs" c="dimmed">
+                    {ticksToHHMMSS(scrubTick)}
+                </Text>
+                <Text size="xs" c="dimmed">
+                    {ticksToHHMMSS(maxTicks)}
+                </Text>
+            </Group>
+        </div>
+    );
+}

--- a/client/src/components/ReplayTimer.tsx
+++ b/client/src/components/ReplayTimer.tsx
@@ -1,4 +1,5 @@
-import { Button, Group, Slider, Stack, Text } from "@mantine/core";
+import { ActionIcon, Group, Slider, Stack, Text, Tooltip } from "@mantine/core";
+import { IconPlayerPauseFilled, IconPlayerPlayFilled, IconPlayerTrackNext } from "@tabler/icons-react";
 import { ReplaySummary } from "dogfight-types/ReplaySummary";
 import { useEffect, useState } from "react";
 import { ReplayCallbacks, ReplayInfo } from "src/hooks/useReplay";
@@ -45,7 +46,18 @@ export function ReplayTimer({ info, callbacks, summary }: ReplayTimerProps) {
                 </Group>
             </div>
             <div>
-                <Button onClick={(_) => callbacks.setPaused(!info.paused)}>{info.paused ? "play" : "pause"}</Button>
+                <Tooltip label={info.paused ? "Play" : "Pause"}>
+                    <ActionIcon onClick={(_) => callbacks.setPaused(!info.paused)}>
+                        {info.paused ? <IconPlayerPlayFilled /> : <IconPlayerPauseFilled />}
+                    </ActionIcon>
+                </Tooltip>
+                {info.paused && (
+                    <Tooltip label={info.paused ? "Play" : "Pause"}>
+                        <ActionIcon onClick={(_) => callbacks.advanceOneTick()}>
+                            <IconPlayerTrackNext />
+                        </ActionIcon>
+                    </Tooltip>
+                )}
             </div>
         </Stack>
     );

--- a/client/src/components/ReplayTimer.tsx
+++ b/client/src/components/ReplayTimer.tsx
@@ -1,5 +1,13 @@
 import { ActionIcon, Group, Slider, Stack, Text, Tooltip } from "@mantine/core";
-import { IconPlayerPauseFilled, IconPlayerPlayFilled, IconPlayerTrackNext } from "@tabler/icons-react";
+import {
+    IconArrowRightBar,
+    IconPlayerPauseFilled,
+    IconPlayerPlayFilled,
+    IconPlayerSkipBackFilled,
+    IconPlayerSkipForwardFilled,
+    IconPlayerTrackNextFilled,
+    IconPlayerTrackPrevFilled,
+} from "@tabler/icons-react";
 import { ReplaySummary } from "dogfight-types/ReplaySummary";
 import { useEffect, useState } from "react";
 import { ReplayCallbacks, ReplayInfo } from "src/hooks/useReplay";
@@ -45,20 +53,41 @@ export function ReplayTimer({ info, callbacks, summary }: ReplayTimerProps) {
                     </Text>
                 </Group>
             </div>
-            <div>
+            <Group gap={4}>
+                <Tooltip label={"-30 seconds"}>
+                    <ActionIcon color={"grape"} onClick={(_) => callbacks.advanceSeconds(-30)}>
+                        <IconPlayerTrackPrevFilled />
+                    </ActionIcon>
+                </Tooltip>
+                <Tooltip label={"-5 seconds"}>
+                    <ActionIcon color={"grape"} onClick={(_) => callbacks.advanceSeconds(-5)}>
+                        <IconPlayerSkipBackFilled />
+                    </ActionIcon>
+                </Tooltip>
                 <Tooltip label={info.paused ? "Play" : "Pause"}>
                     <ActionIcon onClick={(_) => callbacks.setPaused(!info.paused)}>
                         {info.paused ? <IconPlayerPlayFilled /> : <IconPlayerPauseFilled />}
                     </ActionIcon>
                 </Tooltip>
                 {info.paused && (
-                    <Tooltip label={info.paused ? "Play" : "Pause"}>
-                        <ActionIcon onClick={(_) => callbacks.advanceOneTick()}>
-                            <IconPlayerTrackNext />
+                    <Tooltip label={"Advance one frame"}>
+                        <ActionIcon color={"gray"} onClick={(_) => callbacks.advanceOneTick()}>
+                            <IconArrowRightBar />
                         </ActionIcon>
                     </Tooltip>
                 )}
-            </div>
+                <Tooltip label={"+5 seconds"}>
+                    <ActionIcon color={"grape"} onClick={(_) => callbacks.advanceSeconds(5)}>
+                        <IconPlayerSkipForwardFilled />
+                    </ActionIcon>
+                </Tooltip>
+                <Tooltip label={"+30 seconds"}>
+                    <ActionIcon color={"grape"} onClick={(_) => callbacks.advanceSeconds(30)}>
+                        <IconPlayerTrackNextFilled />
+                    </ActionIcon>
+                </Tooltip>
+            </Group>
+            <Group></Group>
         </Stack>
     );
 }

--- a/client/src/components/ReplayTimer.tsx
+++ b/client/src/components/ReplayTimer.tsx
@@ -31,8 +31,6 @@ export function ReplayTimer({ info, callbacks, summary }: ReplayTimerProps) {
                     onChangeEnd={(value) => {
                         setIsScrubbing(false);
                         callbacks.playToTick(value);
-                        //    setIsScrubbing(false);
-                        //   onScrub?.(value);
                     }}
                     onPointerDown={() => setIsScrubbing(true)}
                     styles={{ thumb: { width: 12, height: 12 } }}
@@ -47,7 +45,7 @@ export function ReplayTimer({ info, callbacks, summary }: ReplayTimerProps) {
                 </Group>
             </div>
             <div>
-                <Button>{info.paused ? "play" : "pause"}</Button>
+                <Button onClick={(_) => callbacks.setPaused(!info.paused)}>{info.paused ? "play" : "pause"}</Button>
             </div>
         </Stack>
     );

--- a/client/src/components/ReplayTimer.tsx
+++ b/client/src/components/ReplayTimer.tsx
@@ -1,6 +1,6 @@
 import { Button, Group, Slider, Stack, Text } from "@mantine/core";
 import { ReplaySummary } from "dogfight-types/ReplaySummary";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ReplayCallbacks, ReplayInfo } from "src/hooks/useReplay";
 import { ticksToHHMMSS } from "../helpers";
 
@@ -11,19 +11,26 @@ type ReplayTimerProps = {
 };
 
 export function ReplayTimer({ info, callbacks, summary }: ReplayTimerProps) {
+    const [scrubTick, setScrubTick] = useState(info.tick);
     const [isScrubbing, setIsScrubbing] = useState(false);
+
+    useEffect(() => {
+        if (!isScrubbing) setScrubTick(info.tick);
+    }, [info.tick, isScrubbing]);
 
     return (
         <Stack>
             <div>
                 <Slider
-                    value={info.tick}
+                    value={scrubTick}
                     min={0}
                     max={summary.total_ticks}
                     step={1}
-                    onChange={callbacks.playToTick}
+                    onChange={setScrubTick}
                     label={(e) => ticksToHHMMSS(e)}
                     onChangeEnd={(value) => {
+                        setIsScrubbing(false);
+                        callbacks.playToTick(value);
                         //    setIsScrubbing(false);
                         //   onScrub?.(value);
                     }}

--- a/client/src/components/ReplayTimer.tsx
+++ b/client/src/components/ReplayTimer.tsx
@@ -1,45 +1,47 @@
-import { Group, Slider, Text } from "@mantine/core";
-import { useEffect, useState } from "react";
+import { Button, Group, Slider, Stack, Text } from "@mantine/core";
+import { ReplaySummary } from "dogfight-types/ReplaySummary";
+import { useState } from "react";
+import { ReplayCallbacks, ReplayInfo } from "src/hooks/useReplay";
 import { ticksToHHMMSS } from "../helpers";
 
 type ReplayTimerProps = {
-    currentTick: number;
-    maxTicks: number;
-    onScrub?: (tick: number) => void;
+    info: ReplayInfo;
+    callbacks: ReplayCallbacks;
+    summary: ReplaySummary;
 };
 
-export function ReplayTimer({ currentTick, maxTicks, onScrub }: ReplayTimerProps) {
-    const [scrubTick, setScrubTick] = useState(currentTick);
+export function ReplayTimer({ info, callbacks, summary }: ReplayTimerProps) {
     const [isScrubbing, setIsScrubbing] = useState(false);
 
-    useEffect(() => {
-        if (!isScrubbing) setScrubTick(currentTick);
-    }, [currentTick, isScrubbing]);
-
     return (
-        <div>
-            <Slider
-                value={scrubTick}
-                min={0}
-                max={maxTicks}
-                step={1}
-                onChange={setScrubTick}
-                label={(e) => ticksToHHMMSS(e)}
-                onChangeEnd={(value) => {
-                    setIsScrubbing(false);
-                    onScrub?.(value);
-                }}
-                onPointerDown={() => setIsScrubbing(true)}
-                styles={{ thumb: { width: 12, height: 12 } }}
-            />
-            <Group justify="space-between" mt={4}>
-                <Text size="xs" c="dimmed">
-                    {ticksToHHMMSS(scrubTick)}
-                </Text>
-                <Text size="xs" c="dimmed">
-                    {ticksToHHMMSS(maxTicks)}
-                </Text>
-            </Group>
-        </div>
+        <Stack>
+            <div>
+                <Slider
+                    value={info.tick}
+                    min={0}
+                    max={summary.total_ticks}
+                    step={1}
+                    onChange={callbacks.playToTick}
+                    label={(e) => ticksToHHMMSS(e)}
+                    onChangeEnd={(value) => {
+                        //    setIsScrubbing(false);
+                        //   onScrub?.(value);
+                    }}
+                    onPointerDown={() => setIsScrubbing(true)}
+                    styles={{ thumb: { width: 12, height: 12 } }}
+                />
+                <Group justify="space-between" mt={4}>
+                    <Text size="xs" c="dimmed">
+                        {ticksToHHMMSS(info.tick)}
+                    </Text>
+                    <Text size="xs" c="dimmed">
+                        {ticksToHHMMSS(summary.total_ticks)}
+                    </Text>
+                </Group>
+            </div>
+            <div>
+                <Button>{info.paused ? "play" : "pause"}</Button>
+            </div>
+        </Stack>
     );
 }

--- a/client/src/components/ReplayTimer.tsx
+++ b/client/src/components/ReplayTimer.tsx
@@ -24,6 +24,7 @@ export function ReplayTimer({ currentTick, maxTicks, onScrub }: ReplayTimerProps
                 max={maxTicks}
                 step={1}
                 onChange={setScrubTick}
+                label={(e) => ticksToHHMMSS(e)}
                 onChangeEnd={(value) => {
                     setIsScrubbing(false);
                     onScrub?.(value);

--- a/client/src/gameLoop.ts
+++ b/client/src/gameLoop.ts
@@ -69,7 +69,6 @@ class GameLoop {
     }
 
     public setPaused(paused: boolean) {
-        console.log("AGME LOOP SET PAUSED", paused);
         this.paused = paused;
         if (!paused) {
             this.lastTime = performance.now();

--- a/client/src/gameLoop.ts
+++ b/client/src/gameLoop.ts
@@ -49,9 +49,9 @@ class GameLoop {
             this.requestId = requestAnimationFrame(this.gameLoop);
     };
 
-    public start() {
+    public start(currentTick: number = 0) {
         if (this.requestId) return;
-        this.currentTick = 0;
+        this.currentTick = currentTick;
         this.lastTime = performance.now();
         this.requestId = requestAnimationFrame(this.gameLoop);
     }

--- a/client/src/gameLoop.ts
+++ b/client/src/gameLoop.ts
@@ -1,5 +1,5 @@
 export type TaskFn = (currentTick: number) => void;
-const noop = () => {};
+export const noop = () => {};
 
 /**
  * When facing a case where useInterval or short setTimeout seems handy, use this GameLoop instead
@@ -85,7 +85,7 @@ class Scheduler {
     }
 
     /**
-     * Unregister both recurring or one time tasks from bein run
+     * Unregister both recurring or one time tasks from being run
      */
     unregister(task: TaskFn) {
         this.recurringTasks.delete(task);

--- a/client/src/gameLoop.ts
+++ b/client/src/gameLoop.ts
@@ -42,7 +42,11 @@ class GameLoop {
         }
 
         this.lastTime = time - delta;
-        this.requestId = requestAnimationFrame(this.gameLoop);
+
+        if (this.requestId)
+            // Only request the next animation frame if we haven't called stop(),
+            // which sets requestId to null
+            this.requestId = requestAnimationFrame(this.gameLoop);
     };
 
     public start() {

--- a/client/src/gameLoop.ts
+++ b/client/src/gameLoop.ts
@@ -6,6 +6,7 @@ export const noop = () => {};
  */
 class GameLoop {
     private paused: boolean = false;
+    private advanceTick: boolean = false;
     private currentTick: number = 0;
     private lastTime: number = performance.now();
     private requestId: number | null = null;
@@ -33,12 +34,21 @@ class GameLoop {
     }
 
     private gameLoop = (time: number) => {
+        const doTick = () => {
+            this.currentTick++;
+            this.engineUpdateFn(this.currentTick);
+            this.scheduler.runTasks(this.currentTick);
+        };
+
+        if (this.advanceTick) {
+            doTick();
+            this.advanceTick = false;
+        }
+
         if (!this.paused) {
             let delta = time - this.lastTime;
             while (delta >= this.tickInterval) {
-                this.currentTick++;
-                this.engineUpdateFn(this.currentTick);
-                this.scheduler.runTasks(this.currentTick);
+                doTick();
                 delta -= this.tickInterval;
             }
 
@@ -74,6 +84,11 @@ class GameLoop {
 
     public isRunning() {
         return this.requestId !== null;
+    }
+
+    public advanceOneTick() {
+        this.advanceTick = true;
+        this.lastTime = performance.now();
     }
 }
 

--- a/client/src/helpers.ts
+++ b/client/src/helpers.ts
@@ -9,3 +9,12 @@ export function randomGuid() {
 export function assertNever(value: never, message?: string) {
     throw new Error(`${message ?? "Expected to never get here, got value"}: ${value}`);
 }
+
+export function ticksToHHMMSS(ticks: number): string {
+    const totalSeconds = Math.floor((ticks * 10) / 1000);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}

--- a/client/src/hooks/useDogfight.ts
+++ b/client/src/hooks/useDogfight.ts
@@ -35,9 +35,9 @@ export function useDogfight({ handleClientCommand }: DogfightCallbacks) {
         client.handleGameEvents(events);
     }
 
-    function setMyPlayerGuid(guid: string | null): void {
+    function setMyPlayerGuid(guid: string | null, replay: boolean): void {
         setPlayerGuid(guid);
-        client.setMyPlayerGuid(guid);
+        client.setMyPlayerGuid(guid, replay);
     }
 
     function initialize(div: HTMLDivElement) {

--- a/client/src/hooks/useDogfight.ts
+++ b/client/src/hooks/useDogfight.ts
@@ -20,7 +20,7 @@ export type DogfightCallbacks = {
 
 export function useDogfight({ handleClientCommand }: DogfightCallbacks) {
     const intl = useIntl();
-    let client = useMemo(() => new DogfightClient(), []);
+    const client = useMemo(() => new DogfightClient(), []);
     const engine = useMemo(() => DogfightWeb.new(), []);
 
     // Scoreboard related information
@@ -48,9 +48,6 @@ export function useDogfight({ handleClientCommand }: DogfightCallbacks) {
     );
 
     function initialize(div: HTMLDivElement) {
-        console.log("FUCk");
-        client = new DogfightClient();
-
         // TODO: clean this up, just expose the onCommand directly in the client
         // and write out the command in the client
         const client_callbacks: GameClientCallbacks = {
@@ -120,8 +117,13 @@ export function useDogfight({ handleClientCommand }: DogfightCallbacks) {
         };
     }, []);
 
+    function clearEntities() {
+        client.clearEntities();
+    }
+
     return {
         initialize,
+        clearEntities,
         handleGameEvents,
         setMyPlayerGuid,
         playerGuid,

--- a/client/src/hooks/useDogfight.ts
+++ b/client/src/hooks/useDogfight.ts
@@ -33,7 +33,6 @@ export function useDogfight({ handleClientCommand }: DogfightCallbacks) {
 
     const handleGameEvents = useCallback(
         (events: ServerOutput[]): void => {
-            console.log("FUCKING SHIT");
             client.handleGameEvents(events);
         },
         [client],

--- a/client/src/hooks/useDogfight.ts
+++ b/client/src/hooks/useDogfight.ts
@@ -35,7 +35,7 @@ export function useDogfight({ handleClientCommand }: DogfightCallbacks) {
         client.handleGameEvents(events);
     }
 
-    function setMyPlayerGuid(guid: string): void {
+    function setMyPlayerGuid(guid: string | null): void {
         setPlayerGuid(guid);
         client.setMyPlayerGuid(guid);
     }

--- a/client/src/hooks/useDogfight.ts
+++ b/client/src/hooks/useDogfight.ts
@@ -6,7 +6,7 @@ import { PlayerProperties } from "dogfight-types/PlayerProperties";
 import { ServerOutput } from "dogfight-types/ServerOutput";
 import { Team } from "dogfight-types/Team";
 import { DogfightWeb } from "dogfight-web";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useIntl } from "react-intl";
 import { DogfightClient, GameClientCallbacks } from "../client/DogfightClient";
 import { ChatMessageTimed } from "../components/Chat";
@@ -20,7 +20,7 @@ export type DogfightCallbacks = {
 
 export function useDogfight({ handleClientCommand }: DogfightCallbacks) {
     const intl = useIntl();
-    const client = useMemo(() => new DogfightClient(), []);
+    let client = useMemo(() => new DogfightClient(), []);
     const engine = useMemo(() => DogfightWeb.new(), []);
 
     // Scoreboard related information
@@ -31,16 +31,26 @@ export function useDogfight({ handleClientCommand }: DogfightCallbacks) {
     useGameKeybinds({ client, engine });
     useDevKeybinds({ client, engine });
 
-    function handleGameEvents(events: ServerOutput[]): void {
-        client.handleGameEvents(events);
-    }
+    const handleGameEvents = useCallback(
+        (events: ServerOutput[]): void => {
+            console.log("FUCKING SHIT");
+            client.handleGameEvents(events);
+        },
+        [client],
+    );
 
-    function setMyPlayerGuid(guid: string | null, replay: boolean): void {
-        setPlayerGuid(guid);
-        client.setMyPlayerGuid(guid, replay);
-    }
+    const setMyPlayerGuid = useCallback(
+        (guid: string | null, replay: boolean): void => {
+            setPlayerGuid(guid);
+            client.setMyPlayerGuid(guid, replay);
+        },
+        [client],
+    );
 
     function initialize(div: HTMLDivElement) {
+        console.log("FUCk");
+        client = new DogfightClient();
+
         // TODO: clean this up, just expose the onCommand directly in the client
         // and write out the command in the client
         const client_callbacks: GameClientCallbacks = {

--- a/client/src/hooks/useGuest.ts
+++ b/client/src/hooks/useGuest.ts
@@ -63,7 +63,7 @@ export function useGuest(myName: string, clan: string) {
                         const output: ServerOutput = JSON.parse(data);
                         dogfight.handleGameEvents([output]);
                         if (output.type === "YourPlayerGuid") {
-                            dogfight.setMyPlayerGuid(output.data);
+                            dogfight.setMyPlayerGuid(output.data, false);
                         }
                     } else {
                         // console.log(data)

--- a/client/src/hooks/useLocalHost.ts
+++ b/client/src/hooks/useLocalHost.ts
@@ -85,7 +85,7 @@ export function useLocalHost(gameMap: LevelName, recordGame: boolean, username: 
             console.log(dogfight.engine.get_build_version());
             console.log(dogfight.engine.get_commit());
 
-            dogfight.setMyPlayerGuid(HOST_GUID);
+            dogfight.setMyPlayerGuid(HOST_GUID, false);
 
             hostInput.current.push({
                 player_guid: HOST_GUID,

--- a/client/src/hooks/useReplay.ts
+++ b/client/src/hooks/useReplay.ts
@@ -99,12 +99,18 @@ export function useReplay() {
         };
     }, []);
 
+    function playToTick(tick: number, div: HTMLDivElement) {
+        dogfight.initialize(div);
+        dogfight.engine.load_replay_until(tick);
+    }
+
     return {
         initialize,
         loadReplay,
         replayTime,
         replaySummary,
         spectating,
+        playToTick,
         setSpectating: updateSpectating,
         playerData: dogfight.playerData,
         playerGuid: dogfight.playerGuid,

--- a/client/src/hooks/useReplay.ts
+++ b/client/src/hooks/useReplay.ts
@@ -1,4 +1,3 @@
-import { ReplayEvent } from "dogfight-types/ReplayEvent";
 import { ReplaySummary } from "dogfight-types/ReplaySummary";
 import { ServerOutput } from "dogfight-types/ServerOutput";
 import { useEffect, useRef, useState } from "react";
@@ -20,7 +19,6 @@ export function useReplay() {
     });
 
     const [replaySummary, setReplaySummary] = useState<ReplaySummary | null>(null);
-    const [replayEvents, setReplayEvents] = useState<ReplayEvent[] | null>(null);
     const [spectating, setSpectating] = useState<string | null>(null);
     const [replayTime, setReplayTime] = useState<ReplayTime | null>(null);
     const animateRef = useRef<number | null>(null);
@@ -38,20 +36,17 @@ export function useReplay() {
     };
 
     function loadReplay(binary: Uint8Array): boolean {
-        const replay_string = dogfight.engine.replay_file_binary_to_summary(binary);
+        const replay_string = dogfight.engine.get_replay_summary(binary);
 
         if (!replay_string) {
             setReplaySummary(null);
             return false;
         }
 
-        const replay_file: ReplaySummary = JSON.parse(replay_string);
-        setReplaySummary(replay_file);
+        const summary: ReplaySummary = JSON.parse(replay_string);
+        setReplaySummary(summary);
 
         dogfight.engine.load_replay(binary);
-
-        let events: ReplayEvent[] = JSON.parse(dogfight.engine.get_replay_file_events(binary));
-        setReplayEvents(events);
 
         return true;
     }
@@ -109,7 +104,6 @@ export function useReplay() {
     return {
         initialize,
         loadReplay,
-        replayEvents,
         replayTime,
         replaySummary,
         playerData: dogfight.playerData,

--- a/client/src/hooks/useReplay.ts
+++ b/client/src/hooks/useReplay.ts
@@ -16,6 +16,7 @@ export type ReplayInfo = {
 export type ReplayCallbacks = {
     setPaused: (value: boolean) => void;
     playToTick: (tick: number) => void;
+    advanceOneTick: () => void;
     updateSpectating: (guid: PlayerGuid | null) => void;
     loadReplay: (binary: Uint8Array) => boolean;
 };
@@ -136,11 +137,16 @@ export function useReplay() {
         gameLoop.start(tick);
     }
 
+    function advanceOneTick() {
+        gameLoop.advanceOneTick();
+    }
+
     const replayCallbacks: ReplayCallbacks = {
         setPaused,
         playToTick,
         updateSpectating,
         loadReplay,
+        advanceOneTick,
     };
 
     function setPaused(value: boolean) {

--- a/client/src/hooks/useReplay.ts
+++ b/client/src/hooks/useReplay.ts
@@ -72,9 +72,7 @@ export function useReplay() {
 
         const updateFn = (currentTick: number) => {
             if (currentTick > replaySummary.total_ticks) {
-                console.log("STOPPING GAME LOOP!?");
-                gameLoop.stop();
-                gameLoop.setHostEngineUpdateFn(noop);
+                gameLoop.setHostEngineUpdateFn(noop).stop();
             }
 
             replayTick.current = currentTick;

--- a/client/src/hooks/useReplay.ts
+++ b/client/src/hooks/useReplay.ts
@@ -1,3 +1,4 @@
+import { PlayerGuid } from "dogfight-types/PlayerGuid";
 import { ReplaySummary } from "dogfight-types/ReplaySummary";
 import { ServerOutput } from "dogfight-types/ServerOutput";
 import { useEffect, useRef, useState } from "react";
@@ -19,7 +20,7 @@ export function useReplay() {
     });
 
     const [replaySummary, setReplaySummary] = useState<ReplaySummary | null>(null);
-    const [spectating, setSpectating] = useState<string | null>(null);
+    const [spectating, setSpectating] = useState<PlayerGuid | null>(null);
     const [replayTime, setReplayTime] = useState<ReplayTime | null>(null);
     const animateRef = useRef<number | null>(null);
     const replayTick = useRef<number>(0);
@@ -61,6 +62,13 @@ export function useReplay() {
         return events;
     }
 
+    function updateSpectating(guid: PlayerGuid | null) {
+        setSpectating(guid);
+        if (guid) {
+            dogfight.setMyPlayerGuid(guid);
+        }
+    }
+
     useEffect(() => {
         console.log("REPLAY FILE CHANGED");
         if (!replaySummary) return;
@@ -71,18 +79,6 @@ export function useReplay() {
             }
 
             replayTick.current = currentTick;
-
-            // Just set to the host for now
-            /*
-            if (!spectating) {
-                const host = input.find((x) => x.command.type === "AddPlayer");
-                if (host && host.command.type === "AddPlayer") {
-                    const { name, guid } = host.command.data;
-                    setSpectating(name);
-                    dogfight.setMyPlayerGuid(guid);
-                }
-            }
-            */
 
             // Advances the game one tick based on replay input
             dogfight.engine.tick_replay();
@@ -106,6 +102,8 @@ export function useReplay() {
         loadReplay,
         replayTime,
         replaySummary,
+        spectating,
+        setSpectating: updateSpectating,
         playerData: dogfight.playerData,
         playerGuid: dogfight.playerGuid,
         messages: dogfight.messages,

--- a/client/src/hooks/useReplay.ts
+++ b/client/src/hooks/useReplay.ts
@@ -65,7 +65,7 @@ export function useReplay() {
     function updateSpectating(guid: PlayerGuid | null) {
         setSpectating(guid);
         if (guid) {
-            dogfight.setMyPlayerGuid(guid);
+            dogfight.setMyPlayerGuid(guid, true);
         }
     }
 

--- a/client/src/hooks/useReplay.ts
+++ b/client/src/hooks/useReplay.ts
@@ -1,6 +1,5 @@
 import { ReplayEvent } from "dogfight-types/ReplayEvent";
-import { ReplayFile } from "dogfight-types/ReplayFile";
-import { ServerInput } from "dogfight-types/ServerInput";
+import { ReplaySummary } from "dogfight-types/ReplaySummary";
 import { ServerOutput } from "dogfight-types/ServerOutput";
 import { useEffect, useRef, useState } from "react";
 import { gameLoop } from "../gameLoop";
@@ -20,22 +19,24 @@ export function useReplay() {
         handleClientCommand: () => {},
     });
 
-    const [replayFile, setReplayFile] = useState<ReplayFile | null>(null);
+    const [replaySummary, setReplaySummary] = useState<ReplaySummary | null>(null);
     const [replayEvents, setReplayEvents] = useState<ReplayEvent[] | null>(null);
     const [spectating, setSpectating] = useState<string | null>(null);
     const [replayTime, setReplayTime] = useState<ReplayTime | null>(null);
     const replayTick = useRef<number>(0);
 
     function loadReplay(binary: Uint8Array): boolean {
-        const replay_string = dogfight.engine.replay_file_binary_to_json(binary);
+        const replay_string = dogfight.engine.replay_file_binary_to_summary(binary);
 
         if (!replay_string) {
-            setReplayFile(null);
+            setReplaySummary(null);
             return false;
         }
 
-        const replay_file: ReplayFile = JSON.parse(replay_string);
-        setReplayFile(replay_file);
+        const replay_file: ReplaySummary = JSON.parse(replay_string);
+        setReplaySummary(replay_file);
+
+        dogfight.engine.load_replay(binary);
 
         let events: ReplayEvent[] = JSON.parse(dogfight.engine.get_replay_file_events(binary));
         setReplayEvents(events);
@@ -55,35 +56,17 @@ export function useReplay() {
 
     useEffect(() => {
         console.log("REPLAY FILE CHANGED");
-        if (!replayFile) return;
-
-        dogfight.engine.load_level(replayFile.level_data);
+        if (!replaySummary) return;
 
         const updateFn = (currentTick: number) => {
             if (!gameLoop.isRunning()) {
                 return;
             }
 
-            const tickData = replayFile.ticks[currentTick];
             replayTick.current = currentTick;
 
-            let input: ServerInput[] = [];
-            if (tickData) {
-                input = tickData.map(({ command, player_guid_index }) => {
-                    const player_guid = Object.entries(replayFile.player_guids).find(
-                        ([_, val]) => val === player_guid_index,
-                    )![0];
-
-                    const input: ServerInput = {
-                        player_guid,
-                        command,
-                    };
-
-                    return input;
-                });
-            }
-
             // Just set to the host for now
+            /*
             if (!spectating) {
                 const host = input.find((x) => x.command.type === "AddPlayer");
                 if (host && host.command.type === "AddPlayer") {
@@ -92,9 +75,10 @@ export function useReplay() {
                     dogfight.setMyPlayerGuid(guid);
                 }
             }
+            */
 
-            const input_string = JSON.stringify(input);
-            dogfight.engine.tick(input_string);
+            // Advances the game one tick based on replay input
+            dogfight.engine.tick_replay();
 
             const changed_state = dogfight.engine.flush_changed_state();
             const events = parseServerOutput(changed_state);
@@ -112,7 +96,7 @@ export function useReplay() {
         }
 
         requestAnimationFrame(foo);
-    }, [replayFile]);
+    }, [replaySummary]);
 
     useEffect(() => {
         return () => {
@@ -125,7 +109,7 @@ export function useReplay() {
         loadReplay,
         replayEvents,
         replayTime,
-        replayFile,
+        replaySummary,
         playerData: dogfight.playerData,
         playerGuid: dogfight.playerGuid,
         messages: dogfight.messages,

--- a/client/src/hooks/useReplay.ts
+++ b/client/src/hooks/useReplay.ts
@@ -112,7 +112,7 @@ export function useReplay() {
         if (replayInfo.paused) {
             gameLoop.stop();
         } else {
-            gameLoop.start(replayInfo.tick);
+            gameLoop.start(replayInfo.tick + 1);
         }
         animateRef.current = requestAnimationFrame(animate);
     }, [replaySummary, replayInfo.paused]);

--- a/client/src/hooks/useReplay.ts
+++ b/client/src/hooks/useReplay.ts
@@ -108,12 +108,8 @@ export function useReplay() {
             dogfight.handleGameEvents(events);
         };
 
-        gameLoop.setHostEngineUpdateFn(updateFn);
-        if (replayInfo.paused) {
-            gameLoop.stop();
-        } else {
-            gameLoop.start(replayInfo.tick + 1);
-        }
+        gameLoop.setHostEngineUpdateFn(updateFn).start();
+        gameLoop.setPaused(replayInfo.paused);
         animateRef.current = requestAnimationFrame(animate);
     }, [replaySummary, replayInfo.paused]);
 
@@ -124,6 +120,7 @@ export function useReplay() {
     }, []);
 
     function playToTick(tick: number) {
+        gameLoop.stop();
         replayTick.current = tick;
         setReplayInfo((prev) => ({
             ...prev,
@@ -136,6 +133,7 @@ export function useReplay() {
         const state = dogfight.engine.get_full_state();
         const events = parseServerOutput(state);
         dogfight.handleGameEvents(events);
+        gameLoop.start(tick);
     }
 
     const replayCallbacks: ReplayCallbacks = {

--- a/client/src/hooks/useReplay.ts
+++ b/client/src/hooks/useReplay.ts
@@ -125,6 +125,7 @@ export function useReplay() {
         loadReplay,
         replayEvents,
         replayTime,
+        replayFile,
         playerData: dogfight.playerData,
         playerGuid: dogfight.playerGuid,
         messages: dogfight.messages,

--- a/client/src/hooks/useReplay.ts
+++ b/client/src/hooks/useReplay.ts
@@ -99,17 +99,17 @@ export function useReplay() {
         };
     }, []);
 
-    function playToTick(tick: number, div: HTMLDivElement) {
-        dogfight.initialize(div);
+    function playToTick(tick: number) {
+        dogfight.clearEntities();
+        dogfight.engine.load_replay_until(tick);
+        const state = dogfight.engine.get_full_state();
+        const events = parseServerOutput(state);
+        dogfight.handleGameEvents(events);
         replayTick.current = tick;
         setReplayTime({
             tick: replayTick.current,
             timeString: ticksToHHMMSS(replayTick.current),
         });
-        dogfight.engine.load_replay_until(tick);
-        const state = dogfight.engine.get_full_state();
-        const events = parseServerOutput(state);
-        dogfight.handleGameEvents(events);
     }
 
     return {

--- a/client/src/hooks/useReplay.ts
+++ b/client/src/hooks/useReplay.ts
@@ -101,7 +101,15 @@ export function useReplay() {
 
     function playToTick(tick: number, div: HTMLDivElement) {
         dogfight.initialize(div);
+        replayTick.current = tick;
+        setReplayTime({
+            tick: replayTick.current,
+            timeString: ticksToHHMMSS(replayTick.current),
+        });
         dogfight.engine.load_replay_until(tick);
+        const state = dogfight.engine.get_full_state();
+        const events = parseServerOutput(state);
+        dogfight.handleGameEvents(events);
     }
 
     return {

--- a/client/src/hooks/useReplay.ts
+++ b/client/src/hooks/useReplay.ts
@@ -12,7 +12,7 @@ export type ReplayTime = {
 };
 
 export function useReplay() {
-    console.log("useReplay called!");
+    //console.log("useReplay called!");
 
     const dogfight = useDogfight({
         // We don't want to do anything with commands sent to the replay client
@@ -28,11 +28,13 @@ export function useReplay() {
     const animate = () => {
         if (!gameLoop.isRunning()) return;
 
-        setReplayTime({
-            tick: replayTick.current,
-            timeString: ticksToHHMMSS(replayTick.current),
-        });
-
+        //        console.log(replayTick.current, replayTick.current % 10);
+        if (replayTick.current % 5 === 0) {
+            setReplayTime({
+                tick: replayTick.current,
+                timeString: ticksToHHMMSS(replayTick.current),
+            });
+        }
         animateRef.current = requestAnimationFrame(animate);
     };
 

--- a/client/src/hooks/useReplay.ts
+++ b/client/src/hooks/useReplay.ts
@@ -52,11 +52,11 @@ export function useReplay() {
         dogfight.engine.load_level(replayFile.level_data);
 
         const updateFn = (currentTick: number) => {
-            const tickData = replayFile.ticks.find((x) => x.tick_number === currentTick);
+            const tickData = replayFile.ticks[currentTick];
 
             let input: ServerInput[] = [];
             if (tickData) {
-                input = tickData.commands.map(({ command, player_guid_index }) => {
+                input = tickData.map(({ command, player_guid_index }) => {
                     const player_guid = Object.entries(replayFile.player_guids).find(
                         ([_, val]) => val === player_guid_index,
                     )![0];

--- a/client/src/hooks/useReplay.ts
+++ b/client/src/hooks/useReplay.ts
@@ -91,15 +91,11 @@ export function useReplay() {
     }
 
     useEffect(() => {
-        //console.log("REPLAY FILE CHANGED");
+        console.log("REPLAY FILE CHANGED");
         if (!replaySummary) return;
 
         const updateFn = (currentTick: number) => {
             if (currentTick > replaySummary.total_ticks) {
-                return;
-            }
-
-            if (replayInfo.paused) {
                 return;
             }
 
@@ -112,9 +108,14 @@ export function useReplay() {
             dogfight.handleGameEvents(events);
         };
 
-        gameLoop.setHostEngineUpdateFn(updateFn).start();
+        gameLoop.setHostEngineUpdateFn(updateFn);
+        if (replayInfo.paused) {
+            gameLoop.stop();
+        } else {
+            gameLoop.start(replayInfo.tick);
+        }
         animateRef.current = requestAnimationFrame(animate);
-    }, [replaySummary, replayInfo]);
+    }, [replaySummary, replayInfo.paused]);
 
     useEffect(() => {
         return () => {

--- a/client/src/hooks/useReplay.ts
+++ b/client/src/hooks/useReplay.ts
@@ -2,7 +2,7 @@ import { ReplayEvent } from "dogfight-types/ReplayEvent";
 import { ReplaySummary } from "dogfight-types/ReplaySummary";
 import { ServerOutput } from "dogfight-types/ServerOutput";
 import { useEffect, useRef, useState } from "react";
-import { gameLoop } from "../gameLoop";
+import { gameLoop, noop } from "../gameLoop";
 import { ticksToHHMMSS } from "../helpers";
 import { useDogfight } from "./useDogfight";
 
@@ -59,8 +59,10 @@ export function useReplay() {
         if (!replaySummary) return;
 
         const updateFn = (currentTick: number) => {
-            if (!gameLoop.isRunning()) {
-                return;
+            if (currentTick > replaySummary.total_ticks) {
+                console.log("STOPPING GAME LOOP!?");
+                gameLoop.stop();
+                gameLoop.setHostEngineUpdateFn(noop);
             }
 
             replayTick.current = currentTick;
@@ -92,7 +94,8 @@ export function useReplay() {
                 tick: replayTick.current,
                 timeString: ticksToHHMMSS(replayTick.current),
             });
-            requestAnimationFrame(foo);
+
+            if (gameLoop.isRunning()) requestAnimationFrame(foo);
         }
 
         requestAnimationFrame(foo);

--- a/client/src/hooks/useReplay.ts
+++ b/client/src/hooks/useReplay.ts
@@ -1,3 +1,4 @@
+import { ReplayEvent } from "dogfight-types/ReplayEvent";
 import { ReplayFile } from "dogfight-types/ReplayFile";
 import { ServerInput } from "dogfight-types/ServerInput";
 import { ServerOutput } from "dogfight-types/ServerOutput";
@@ -14,10 +15,12 @@ export function useReplay() {
     });
 
     const [replayFile, setReplayFile] = useState<ReplayFile | null>(null);
+    const [replayEvents, setReplayEvents] = useState<ReplayEvent[] | null>(null);
     const [spectating, setSpectating] = useState<string | null>(null);
 
     function loadReplay(binary: Uint8Array): boolean {
         const replay_string = dogfight.engine.replay_file_binary_to_json(binary);
+
         if (!replay_string) {
             setReplayFile(null);
             return false;
@@ -25,6 +28,9 @@ export function useReplay() {
 
         const replay_file: ReplayFile = JSON.parse(replay_string);
         setReplayFile(replay_file);
+
+        let events: ReplayEvent[] = JSON.parse(dogfight.engine.get_replay_file_events(binary));
+        setReplayEvents(events);
 
         return true;
     }
@@ -94,6 +100,7 @@ export function useReplay() {
     return {
         initialize,
         loadReplay,
+        replayEvents,
         playerData: dogfight.playerData,
         playerGuid: dogfight.playerGuid,
         messages: dogfight.messages,

--- a/client/src/hooks/useReplay.ts
+++ b/client/src/hooks/useReplay.ts
@@ -17,6 +17,7 @@ export type ReplayCallbacks = {
     setPaused: (value: boolean) => void;
     playToTick: (tick: number) => void;
     advanceOneTick: () => void;
+    advanceSeconds: (seconds: number) => void;
     updateSpectating: (guid: PlayerGuid | null) => void;
     loadReplay: (binary: Uint8Array) => boolean;
 };
@@ -141,12 +142,21 @@ export function useReplay() {
         gameLoop.advanceOneTick();
     }
 
+    function advanceSeconds(seconds: number) {
+        const ticks = seconds * 100;
+        let target = replayInfo.tick + ticks;
+        if (target < 0) target = 0;
+        if (target > (replaySummary?.total_ticks ?? 1)) target = 1;
+        playToTick(target);
+    }
+
     const replayCallbacks: ReplayCallbacks = {
         setPaused,
         playToTick,
         updateSpectating,
         loadReplay,
         advanceOneTick,
+        advanceSeconds,
     };
 
     function setPaused(value: boolean) {

--- a/client/src/views/Replay.tsx
+++ b/client/src/views/Replay.tsx
@@ -24,6 +24,7 @@ export function Replay() {
         playerData,
         playerGuid,
         messages,
+        playToTick,
     } = useReplay();
 
     const [state, setState] = useState<ReplayState>(ReplayState.ProvideFile);
@@ -55,6 +56,14 @@ export function Replay() {
         reader.readAsArrayBuffer(payload);
     }
 
+    function setTick(tick: number): void {
+        console.log("TRY TO JUMP TO", tick);
+        if (gameContainer.current) {
+            playToTick(tick, gameContainer.current);
+        }
+        //
+    }
+
     return (
         <Group justify="center">
             <Game
@@ -67,6 +76,7 @@ export function Replay() {
             {state === ReplayState.Watching && (
                 <Stack>
                     <ReplayControls
+                        onScrub={setTick}
                         players={replaySummary?.players ?? {}}
                         events={replaySummary?.events ?? []}
                         currentTick={replayTime?.tick ?? 0}

--- a/client/src/views/Replay.tsx
+++ b/client/src/views/Replay.tsx
@@ -13,7 +13,7 @@ enum ReplayState {
 
 export function Replay() {
     const intl = useIntl();
-    const { loadReplay, replayEvents, initialize, playerData, playerGuid, messages } = useReplay();
+    const { loadReplay, replayEvents, replayTime, initialize, playerData, playerGuid, messages } = useReplay();
 
     const [state, setState] = useState<ReplayState>(ReplayState.ProvideFile);
     const gameContainer = useRef<HTMLDivElement>(null);
@@ -55,6 +55,7 @@ export function Replay() {
             />
             {state === ReplayState.Watching && (
                 <div>
+                    <div>Time: {replayTime?.timeString}</div>
                     <div>Events: {JSON.stringify(replayEvents)}</div>
                 </div>
             )}

--- a/client/src/views/Replay.tsx
+++ b/client/src/views/Replay.tsx
@@ -3,6 +3,7 @@ import { IconFileUpload, IconInfoCircle } from "@tabler/icons-react";
 import { useRef, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Game } from "../components/Game";
+import { ReplayTimer } from "../components/ReplayTimer";
 import { useReplay } from "../hooks/useReplay";
 
 enum ReplayState {
@@ -13,7 +14,8 @@ enum ReplayState {
 
 export function Replay() {
     const intl = useIntl();
-    const { loadReplay, replayEvents, replayTime, initialize, playerData, playerGuid, messages } = useReplay();
+    const { loadReplay, replayFile, replayEvents, replayTime, initialize, playerData, playerGuid, messages } =
+        useReplay();
 
     const [state, setState] = useState<ReplayState>(ReplayState.ProvideFile);
     const gameContainer = useRef<HTMLDivElement>(null);
@@ -54,10 +56,11 @@ export function Replay() {
                 onSendMessage={() => {}}
             />
             {state === ReplayState.Watching && (
-                <div>
+                <Stack>
+                    <ReplayTimer currentTick={replayTime?.tick ?? 0} maxTicks={100 * 20} />
                     <div>Time: {replayTime?.timeString}</div>
                     <div>Events: {JSON.stringify(replayEvents)}</div>
-                </div>
+                </Stack>
             )}
             {state === ReplayState.ProvideFile && (
                 <div>

--- a/client/src/views/Replay.tsx
+++ b/client/src/views/Replay.tsx
@@ -3,7 +3,7 @@ import { IconFileUpload, IconInfoCircle } from "@tabler/icons-react";
 import { useRef, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { Game } from "../components/Game";
-import { ReplayTimer } from "../components/ReplayTimer";
+import { ReplayControls } from "../components/ReplayControls";
 import { useReplay } from "../hooks/useReplay";
 
 enum ReplayState {
@@ -14,7 +14,17 @@ enum ReplayState {
 
 export function Replay() {
     const intl = useIntl();
-    const { loadReplay, replaySummary, replayTime, initialize, playerData, playerGuid, messages } = useReplay();
+    const {
+        loadReplay,
+        replaySummary,
+        spectating,
+        setSpectating,
+        replayTime,
+        initialize,
+        playerData,
+        playerGuid,
+        messages,
+    } = useReplay();
 
     const [state, setState] = useState<ReplayState>(ReplayState.ProvideFile);
     const gameContainer = useRef<HTMLDivElement>(null);
@@ -56,9 +66,14 @@ export function Replay() {
             />
             {state === ReplayState.Watching && (
                 <Stack>
-                    <ReplayTimer currentTick={replayTime?.tick ?? 0} maxTicks={replaySummary?.total_ticks ?? 1} />
-                    <div>Time: {replayTime?.timeString}</div>
-                    <div>Events: {JSON.stringify(replaySummary?.events)}</div>
+                    <ReplayControls
+                        players={replaySummary?.players ?? {}}
+                        events={replaySummary?.events ?? []}
+                        currentTick={replayTime?.tick ?? 0}
+                        maxTicks={replaySummary?.total_ticks ?? 1}
+                        spectating={spectating}
+                        setSpectating={setSpectating}
+                    />
                 </Stack>
             )}
             {state === ReplayState.ProvideFile && (

--- a/client/src/views/Replay.tsx
+++ b/client/src/views/Replay.tsx
@@ -14,8 +14,7 @@ enum ReplayState {
 
 export function Replay() {
     const intl = useIntl();
-    const { loadReplay, replaySummary, replayEvents, replayTime, initialize, playerData, playerGuid, messages } =
-        useReplay();
+    const { loadReplay, replaySummary, replayTime, initialize, playerData, playerGuid, messages } = useReplay();
 
     const [state, setState] = useState<ReplayState>(ReplayState.ProvideFile);
     const gameContainer = useRef<HTMLDivElement>(null);
@@ -59,7 +58,7 @@ export function Replay() {
                 <Stack>
                     <ReplayTimer currentTick={replayTime?.tick ?? 0} maxTicks={replaySummary?.total_ticks ?? 1} />
                     <div>Time: {replayTime?.timeString}</div>
-                    <div>Events: {JSON.stringify(replayEvents)}</div>
+                    <div>Events: {JSON.stringify(replaySummary?.events)}</div>
                 </Stack>
             )}
             {state === ReplayState.ProvideFile && (

--- a/client/src/views/Replay.tsx
+++ b/client/src/views/Replay.tsx
@@ -13,7 +13,7 @@ enum ReplayState {
 
 export function Replay() {
     const intl = useIntl();
-    const { loadReplay, initialize, playerData, playerGuid, messages } = useReplay();
+    const { loadReplay, replayEvents, initialize, playerData, playerGuid, messages } = useReplay();
 
     const [state, setState] = useState<ReplayState>(ReplayState.ProvideFile);
     const gameContainer = useRef<HTMLDivElement>(null);
@@ -53,6 +53,7 @@ export function Replay() {
                 messages={messages}
                 onSendMessage={() => {}}
             />
+            <div>Events: {JSON.stringify(replayEvents)}</div>
             {state === ReplayState.ProvideFile && (
                 <div>
                     <Group>

--- a/client/src/views/Replay.tsx
+++ b/client/src/views/Replay.tsx
@@ -59,9 +59,8 @@ export function Replay() {
     function setTick(tick: number): void {
         console.log("TRY TO JUMP TO", tick);
         if (gameContainer.current) {
-            playToTick(tick, gameContainer.current);
+            playToTick(tick);
         }
-        //
     }
 
     return (

--- a/client/src/views/Replay.tsx
+++ b/client/src/views/Replay.tsx
@@ -14,18 +14,7 @@ enum ReplayState {
 
 export function Replay() {
     const intl = useIntl();
-    const {
-        loadReplay,
-        replaySummary,
-        spectating,
-        setSpectating,
-        replayTime,
-        initialize,
-        playerData,
-        playerGuid,
-        messages,
-        playToTick,
-    } = useReplay();
+    const { replaySummary, replayCallbacks, initialize, playerData, playerGuid, messages, replayInfo } = useReplay();
 
     const [state, setState] = useState<ReplayState>(ReplayState.ProvideFile);
     const gameContainer = useRef<HTMLDivElement>(null);
@@ -43,7 +32,7 @@ export function Replay() {
 
                 if (gameContainer.current) {
                     initialize(gameContainer.current);
-                    const didReadFile = loadReplay(bytes);
+                    const didReadFile = replayCallbacks.loadReplay(bytes);
 
                     if (didReadFile) {
                         setState(ReplayState.Watching);
@@ -54,13 +43,6 @@ export function Replay() {
             }
         };
         reader.readAsArrayBuffer(payload);
-    }
-
-    function setTick(tick: number): void {
-        console.log("TRY TO JUMP TO", tick);
-        if (gameContainer.current) {
-            playToTick(tick);
-        }
     }
 
     return (
@@ -74,15 +56,15 @@ export function Replay() {
             />
             {state === ReplayState.Watching && (
                 <Stack>
-                    <ReplayControls
-                        onScrub={setTick}
-                        players={replaySummary?.players ?? {}}
-                        events={replaySummary?.events ?? []}
-                        currentTick={replayTime?.tick ?? 0}
-                        maxTicks={replaySummary?.total_ticks ?? 1}
-                        spectating={spectating}
-                        setSpectating={setSpectating}
-                    />
+                    {replaySummary && (
+                        <ReplayControls
+                            players={replaySummary?.players ?? {}}
+                            events={replaySummary?.events ?? []}
+                            info={replayInfo}
+                            callbacks={replayCallbacks}
+                            summary={replaySummary}
+                        />
+                    )}
                 </Stack>
             )}
             {state === ReplayState.ProvideFile && (

--- a/client/src/views/Replay.tsx
+++ b/client/src/views/Replay.tsx
@@ -14,7 +14,7 @@ enum ReplayState {
 
 export function Replay() {
     const intl = useIntl();
-    const { loadReplay, replayFile, replayEvents, replayTime, initialize, playerData, playerGuid, messages } =
+    const { loadReplay, replaySummary, replayEvents, replayTime, initialize, playerData, playerGuid, messages } =
         useReplay();
 
     const [state, setState] = useState<ReplayState>(ReplayState.ProvideFile);
@@ -57,7 +57,7 @@ export function Replay() {
             />
             {state === ReplayState.Watching && (
                 <Stack>
-                    <ReplayTimer currentTick={replayTime?.tick ?? 0} maxTicks={100 * 20} />
+                    <ReplayTimer currentTick={replayTime?.tick ?? 0} maxTicks={replaySummary?.total_ticks ?? 1} />
                     <div>Time: {replayTime?.timeString}</div>
                     <div>Events: {JSON.stringify(replayEvents)}</div>
                 </Stack>

--- a/client/src/views/Replay.tsx
+++ b/client/src/views/Replay.tsx
@@ -53,7 +53,11 @@ export function Replay() {
                 messages={messages}
                 onSendMessage={() => {}}
             />
-            <div>Events: {JSON.stringify(replayEvents)}</div>
+            {state === ReplayState.Watching && (
+                <div>
+                    <div>Events: {JSON.stringify(replayEvents)}</div>
+                </div>
+            )}
             {state === ReplayState.ProvideFile && (
                 <div>
                     <Group>

--- a/dogfight/dogfight-web/src/lib.rs
+++ b/dogfight/dogfight-web/src/lib.rs
@@ -8,7 +8,7 @@ use dogfight::{
         player_command_json_from_binary, player_command_json_to_binary, replay_file_binary_to_json,
     },
     output::ServerOutput,
-    replay::{get_build_version, get_commit_version},
+    replay::file::{get_build_version, get_commit_version},
     world::World,
 };
 use wasm_bindgen::prelude::*;

--- a/dogfight/dogfight-web/src/lib.rs
+++ b/dogfight/dogfight-web/src/lib.rs
@@ -8,7 +8,10 @@ use dogfight::{
         player_command_json_from_binary, player_command_json_to_binary, replay_file_binary_to_json,
     },
     output::ServerOutput,
-    replay::file::{get_build_version, get_commit_version},
+    replay::{
+        events::get_replay_file_events,
+        file::{get_build_version, get_commit_version},
+    },
     world::World,
 };
 use wasm_bindgen::prelude::*;
@@ -47,6 +50,10 @@ impl DogfightWeb {
 
     pub fn get_commit(&self) -> String {
         get_commit_version().to_string()
+    }
+
+    pub fn get_replay_file_events(&self, bytes: Vec<u8>) -> String {
+        get_replay_file_events(bytes)
     }
 
     pub fn replay_file_binary_to_json(&self, bytes: Vec<u8>) -> String {

--- a/dogfight/dogfight-web/src/lib.rs
+++ b/dogfight/dogfight-web/src/lib.rs
@@ -12,7 +12,7 @@ use dogfight::{
         events::get_replay_summary,
         file::{get_build_version, get_commit_version, ReplayFile},
     },
-    world::World,
+    world::{self, World},
 };
 use wasm_bindgen::prelude::*;
 
@@ -89,6 +89,14 @@ impl DogfightWeb {
     pub fn tick(&mut self, input_json: String) -> () {
         let input = game_input_from_string(input_json);
         self.world.tick(input);
+    }
+
+    pub fn load_replay_until(&mut self, until_tick: u32) -> () {
+        if let Some(replay) = &self.replay {
+            self.world = World::new();
+            self.world.load_level(&replay.level_data);
+            self.world.simulate_until(replay, Some(until_tick), true);
+        }
     }
 
     pub fn tick_replay(&mut self) -> () {

--- a/dogfight/dogfight-web/src/lib.rs
+++ b/dogfight/dogfight-web/src/lib.rs
@@ -6,11 +6,10 @@ use dogfight::{
     network::{
         encoding::NetworkedBytes, game_events_from_bytes, game_events_to_binary,
         game_events_to_json, player_command_json_from_binary, player_command_json_to_binary,
-        replay_file_binary_to_summary,
     },
     output::ServerOutput,
     replay::{
-        events::get_replay_file_events,
+        events::get_replay_summary,
         file::{get_build_version, get_commit_version, ReplayFile},
     },
     world::World,
@@ -63,12 +62,8 @@ impl DogfightWeb {
         get_commit_version().to_string()
     }
 
-    pub fn get_replay_file_events(&self, bytes: Vec<u8>) -> String {
-        get_replay_file_events(bytes)
-    }
-
-    pub fn replay_file_binary_to_summary(&self, bytes: Vec<u8>) -> String {
-        replay_file_binary_to_summary(bytes)
+    pub fn get_replay_summary(&self, bytes: Vec<u8>) -> String {
+        get_replay_summary(bytes)
     }
 
     pub fn parse_level(&self, level_str: &str) -> String {

--- a/dogfight/src/collision.rs
+++ b/dogfight/src/collision.rs
@@ -96,9 +96,9 @@ pub trait SolidEntity: Entity {
             let img_self = self.get_collision_image();
             let img_other = other.get_collision_image();
 
-            // web_sys::console::log_1(&format!("{:?}", intersection).into());
-            // web_sys::console::log_1(&format!("{:?}", img_self).into());
-            // web_sys::console::log_1(&format!("{:?}", img_other).into());
+            // log(&format!("{:?}", intersection).into());
+            // log(&format!("{:?}", img_self).into());
+            // log(&format!("{:?}", img_other).into());
 
             if img_self.is_none() && img_other.is_none() {
                 return true;
@@ -106,20 +106,20 @@ pub trait SolidEntity: Entity {
 
             if let Some(img) = img_self {
                 if img_other.is_none() && check_pixels(img, &intersection, &bounds_self) {
-                    // web_sys::console::log_1(&format!("img self: {:?}", intersection).into());
+                    // log(&format!("img self: {:?}", intersection).into());
                     return true;
                 }
             }
 
             if let Some(img) = img_other {
                 if img_self.is_none() && check_pixels(img, &intersection, &bounds_other) {
-                    //  web_sys::console::log_1(&format!("img other: {:?}", intersection).into());
+                    //  log(&format!("img other: {:?}", intersection).into());
                     return true;
                 }
             }
 
             if let (Some(img_self), Some(img_other)) = (img_self, img_other) {
-                // web_sys::console::log_1(&format!("double pixels: {:?}", intersection).into());
+                // log(&format!("double pixels: {:?}", intersection).into());
                 return check_pixel_collision(
                     img_self,
                     &intersection,
@@ -163,7 +163,7 @@ fn check_pixels(image: &RgbaImage, intersection: &BoundingBox, bounds: &Bounding
             let pixel_x = intersection.x + x - bounds.x;
             let pixel_y = intersection.y + y - bounds.y;
             if image.get_pixel(pixel_x as u32, pixel_y as u32).0[3] != 0 {
-                // web_sys::console::log_1(&format!("x: {} y: {}", pixel_x, pixel_y).into());
+                // log(&format!("x: {} y: {}", pixel_x, pixel_y).into());
                 return true;
             }
         }

--- a/dogfight/src/entities/container.rs
+++ b/dogfight/src/entities/container.rs
@@ -178,7 +178,7 @@ where
 
         /*
         if removed.len() > 0 {
-            web_sys::console::log_1(&format!("ids len: {}", self.ids.len()).into());
+            log(&format!("ids len: {}", self.ids.len()).into());
         }
         */
 

--- a/dogfight/src/entities/plane.rs
+++ b/dogfight/src/entities/plane.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 
 use crate::{
     collision::{BoundingBox, SolidEntity},
+    debug::log,
     game_event::{KillEvent, KillMethod},
     images::{
         get_image, get_rotateable_image, rotate_image, PLANE4, PLANE5, PLANE6, PLANE7, PLANE8,
@@ -237,7 +238,7 @@ impl Plane {
     ) -> Vec<Action> {
         let mut actions = vec![];
 
-        // web_sys::console::log_1(&format!("ticking plane! {:?}", self.mode.get()).into());
+        // log(&format!("ticking plane! {:?}", self.mode.get()).into());
 
         // Add a tick to our counters
         self.last_bomb_ms += 10;
@@ -316,12 +317,12 @@ impl Plane {
     }
 
     fn park(&mut self, runway: &Runway) -> () {
-        web_sys::console::log_1(&format!("start_x {}", runway.get_start_x()).into());
+        log(format!("start_x {}", runway.get_start_x()).into());
         self.set_client_x(runway.get_start_x());
 
-        web_sys::console::log_1(&format!("start_y {}", runway.get_start_y()).into());
+        log(format!("start_y {}", runway.get_start_y()).into());
         self.set_client_y(runway.get_start_y() - self.get_bottom_height());
-        web_sys::console::log_1(&format!("bottom_height {}", self.get_bottom_height()).into());
+        log(format!("bottom_height {}", self.get_bottom_height()).into());
 
         if runway.get_facing() == Facing::Left {
             self.set_angle(PI);
@@ -485,14 +486,14 @@ impl Plane {
         if self.speed != 0.0 {
             // TODO: this should probably be speed per pixel instead, it's distinct
             let res = RESOLUTION as f64;
-            //web_sys::console::log_1(&format!("x before: {}", self.x).into());
-            //web_sys::console::log_1(&format!("y before: {}", self.y).into());
+            //log(&format!("x before: {}", self.x).into());
+            //log(&format!("y before: {}", self.y).into());
 
             self.x += (res * self.angle.cos() * self.speed / res) as i32;
             self.y += (res * self.angle.sin() * self.speed / res) as i32;
 
-            //web_sys::console::log_1(&format!("x after: {}", self.x).into());
-            //web_sys::console::log_1(&format!("y after: {}", self.y).into());
+            //log(&format!("x after: {}", self.x).into());
+            //log(&format!("y after: {}", self.y).into());
             self.client_x.set((self.x / RESOLUTION) as i16);
             self.client_y.set((self.y / RESOLUTION) as i16);
         }
@@ -766,7 +767,7 @@ impl Plane {
         /*
         let image = self.get_image();
         let (width, height) = image.dimensions();
-        web_sys::console::log_1(&format!("img width: {} height: {}", width, height).into());
+        log(&format!("img width: {} height: {}", width, height).into());
 
         for y in (0..height).rev() {
             for x in 0..width {

--- a/dogfight/src/entities/player.rs
+++ b/dogfight/src/entities/player.rs
@@ -12,6 +12,7 @@ use super::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS, PartialOrd, Ord)]
+#[ts(export)]
 pub struct PlayerGuid(String);
 
 impl NetworkedBytes for PlayerGuid {

--- a/dogfight/src/entities/player.rs
+++ b/dogfight/src/entities/player.rs
@@ -3,12 +3,30 @@ use crate::{
     network::{property::*, EntityProperties, NetworkedEntity},
 };
 use dogfight_macros::{EnumBytes, Networked};
+use serde::Deserialize;
 
 use super::{
     container::{ManId, PlaneId, RunwayId},
     plane::PlaneType,
     types::Team,
 };
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS, PartialOrd, Ord)]
+pub struct PlayerGuid(String);
+
+impl NetworkedBytes for PlayerGuid {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.0.to_bytes()
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<(&[u8], Self)>
+    where
+        Self: Sized,
+    {
+        let (bytes, guid) = String::from_bytes(bytes)?;
+        Some((bytes, Self(guid)))
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, TS, EnumBytes)]
 #[ts(export)]
@@ -80,7 +98,7 @@ pub struct Player {
 
     keys: PlayerKeyboard,
 
-    guid: Property<String>,
+    guid: Property<PlayerGuid>,
     name: Property<String>,
     #[rustfmt::skip]
     clan: Property<Option::<String>>,
@@ -95,7 +113,7 @@ pub struct Player {
 }
 
 impl Player {
-    pub fn new(guid: String, name: String, clan: Option<String>) -> Self {
+    pub fn new(guid: PlayerGuid, name: String, clan: Option<String>) -> Self {
         Player {
             shots: 0,
             hits: 0,
@@ -168,7 +186,7 @@ impl Player {
         self.name.get().clone()
     }
 
-    pub fn get_guid(&self) -> &String {
+    pub fn get_guid(&self) -> &PlayerGuid {
         self.guid.get()
     }
 

--- a/dogfight/src/input.rs
+++ b/dogfight/src/input.rs
@@ -5,7 +5,7 @@ use crate::{
     entities::{
         container::RunwayId,
         plane::{Plane, PlaneType},
-        player::{ControllingEntity, Player, PlayerState},
+        player::{ControllingEntity, Player, PlayerGuid, PlayerState},
         runway::RunwayReservation,
         types::Team,
     },
@@ -21,7 +21,7 @@ use crate::{
 #[derive(Serialize, Deserialize, Debug, TS)]
 #[ts(export)]
 pub struct ServerInput {
-    pub player_guid: String,
+    pub player_guid: PlayerGuid,
     pub command: PlayerCommand,
 }
 
@@ -143,7 +143,7 @@ pub struct TeamSelection {
 #[derive(Serialize, Deserialize, Debug, TS, Clone)]
 #[ts(export)]
 pub struct AddPlayerData {
-    pub guid: String,
+    pub guid: PlayerGuid,
     pub name: String,
     pub clan: Option<String>,
 }
@@ -161,7 +161,7 @@ impl NetworkedBytes for AddPlayerData {
     where
         Self: Sized,
     {
-        let (bytes, guid) = String::from_bytes(bytes)?;
+        let (bytes, guid) = PlayerGuid::from_bytes(bytes)?;
         let (bytes, name) = String::from_bytes(bytes)?;
         let (bytes, clan) = Option::<String>::from_bytes(bytes)?;
 
@@ -240,7 +240,7 @@ impl World {
         game_output
     }
 
-    pub(crate) fn process_takeoff(&mut self, guid: &String, selection: RunwaySelection) {
+    pub(crate) fn process_takeoff(&mut self, guid: &PlayerGuid, selection: RunwaySelection) {
         let maybe_team = self
             .get_player_from_guid(guid)
             .and_then(|p| p.1.get_team().clone());

--- a/dogfight/src/input.rs
+++ b/dogfight/src/input.rs
@@ -226,12 +226,15 @@ impl World {
                 }
                 PlayerCommand::SendMessage(message, is_global) => {
                     if let Some((_, player)) = self.get_player_from_guid(&guid) {
-                        game_output.push(ServerOutput::ChatMessage(ChatMessage {
-                            message,
-                            private: !is_global,
-                            sender_name: Some(player.get_full_name()),
-                            team: *player.get_team(),
-                        }));
+                        game_output.push(ServerOutput::ChatMessage(
+                            player.get_guid().clone(),
+                            ChatMessage {
+                                message,
+                                private: !is_global,
+                                sender_name: Some(player.get_full_name()),
+                                team: *player.get_team(),
+                            },
+                        ));
                     }
                 }
             };

--- a/dogfight/src/network/mod.rs
+++ b/dogfight/src/network/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     input::PlayerCommand,
     output::ServerOutput,
-    replay::{ReplayFile, ReplayTick},
+    replay::file::{ReplayFile, ReplayTick},
 };
 
 use self::encoding::NetworkedBytes;

--- a/dogfight/src/network/mod.rs
+++ b/dogfight/src/network/mod.rs
@@ -58,15 +58,6 @@ pub fn replay_file_json_to_binary(replay_file_json: &str) -> Vec<u8> {
     input.to_bytes()
 }
 
-pub fn replay_file_binary_to_summary(bytes: Vec<u8>) -> String {
-    match ReplayFile::from_bytes(&bytes) {
-        Some((_, replay_file)) => {
-            serde_json::to_string::<ReplaySummary>(&replay_file.try_into().unwrap()).unwrap()
-        }
-        None => "".to_string(),
-    }
-}
-
 pub fn replay_tick_json_to_binary(replay_tick_json: &str) -> Vec<u8> {
     let input = serde_json::from_str::<ReplayTick>(&replay_tick_json).unwrap();
     input.to_bytes()

--- a/dogfight/src/network/mod.rs
+++ b/dogfight/src/network/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     input::PlayerCommand,
     output::ServerOutput,
-    replay::file::{ReplayFile, ReplayTick},
+    replay::file::{ReplayFile, ReplaySummary, ReplayTick},
 };
 
 use self::encoding::NetworkedBytes;
@@ -58,9 +58,11 @@ pub fn replay_file_json_to_binary(replay_file_json: &str) -> Vec<u8> {
     input.to_bytes()
 }
 
-pub fn replay_file_binary_to_json(bytes: Vec<u8>) -> String {
+pub fn replay_file_binary_to_summary(bytes: Vec<u8>) -> String {
     match ReplayFile::from_bytes(&bytes) {
-        Some((_, replay_file)) => serde_json::to_string(&replay_file).unwrap(),
+        Some((_, replay_file)) => {
+            serde_json::to_string::<ReplaySummary>(&replay_file.try_into().unwrap()).unwrap()
+        }
         None => "".to_string(),
     }
 }

--- a/dogfight/src/network/mod.rs
+++ b/dogfight/src/network/mod.rs
@@ -33,7 +33,7 @@ pub(crate) fn entity_changes_to_json(state: Vec<EntityChange>) -> String {
 */
 
 pub(crate) fn entity_changes_to_binary(state: &Vec<EntityChange>) -> Vec<u8> {
-    //web_sys::console::log_1(&format!("{:?}", state).into());
+    //log(&format!("{:?}", state).into());
     state.iter().flat_map(|x| x.to_bytes()).collect()
 }
 
@@ -75,7 +75,7 @@ fn player_command_from_json(command_json: &str) -> PlayerCommand {
 }
 
 pub fn game_events_from_bytes(bytes: &Vec<u8>) -> Vec<ServerOutput> {
-    //web_sys::console::log_1(&format!("data: {:?}", bytes).into());
+    //log(&format!("data: {:?}", bytes).into());
     match Vec::<ServerOutput>::from_bytes(bytes) {
         Some((_, events)) => events,
         None => vec![],

--- a/dogfight/src/replay/encoding.rs
+++ b/dogfight/src/replay/encoding.rs
@@ -1,0 +1,94 @@
+use std::collections::BTreeMap;
+
+use crate::{input::PlayerCommand, network::encoding::NetworkedBytes};
+
+use super::file::{ReplayFile, ReplayTick, ReplayTickCommand};
+
+impl NetworkedBytes for ReplayTick {
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = vec![];
+        bytes.extend(u32::to_bytes(&self.tick_number));
+        bytes.extend(Vec::<ReplayTickCommand>::to_bytes(&self.commands));
+        bytes
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<(&[u8], Self)>
+    where
+        Self: Sized,
+    {
+        let (mut bytes, tick_number) = u32::from_bytes(bytes)?;
+        let (slice, commands) = Vec::<ReplayTickCommand>::from_bytes(bytes)?;
+        bytes = slice;
+        Some((
+            bytes,
+            Self {
+                tick_number,
+                commands,
+            },
+        ))
+    }
+}
+
+impl NetworkedBytes for ReplayFile {
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = vec![];
+
+        // look how pretty this is
+        bytes.extend(self.player_guids.to_bytes());
+        bytes.extend(self.ticks.to_bytes());
+        bytes.extend(self.level_name.to_bytes());
+        bytes.extend(self.level_data.to_bytes());
+        bytes.extend(self.build_version.to_bytes());
+        bytes.extend(self.build_commit.to_bytes());
+
+        bytes
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<(&[u8], Self)>
+    where
+        Self: Sized,
+    {
+        let (bytes, player_guids) = BTreeMap::<String, u16>::from_bytes(bytes)?;
+        let (bytes, ticks) = Vec::<ReplayTick>::from_bytes(bytes)?;
+        let (bytes, level_name) = String::from_bytes(bytes)?;
+        let (bytes, level_data) = String::from_bytes(bytes)?;
+        let (bytes, build_version) = String::from_bytes(bytes)?;
+        let (bytes, build_commit) = String::from_bytes(bytes)?;
+
+        Some((
+            bytes,
+            Self {
+                build_version,
+                build_commit,
+                level_name,
+                level_data,
+                player_guids,
+                ticks,
+            },
+        ))
+    }
+}
+
+impl NetworkedBytes for ReplayTickCommand {
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = vec![];
+        bytes.extend(self.player_guid_index.to_bytes());
+        bytes.extend(self.command.to_bytes());
+        bytes
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<(&[u8], Self)>
+    where
+        Self: Sized,
+    {
+        let (bytes, player_guid_index) = u16::from_bytes(bytes)?;
+        let (bytes, command) = PlayerCommand::from_bytes(bytes)?;
+        Some((
+            bytes,
+            Self {
+                player_guid_index,
+                command,
+            },
+        ))
+    }
+}

--- a/dogfight/src/replay/encoding.rs
+++ b/dogfight/src/replay/encoding.rs
@@ -1,6 +1,8 @@
 use std::collections::{BTreeMap, HashMap};
 
-use crate::{input::PlayerCommand, network::encoding::NetworkedBytes};
+use crate::{
+    entities::player::PlayerGuid, input::PlayerCommand, network::encoding::NetworkedBytes,
+};
 
 use super::file::{ReplayFile, ReplayTick, ReplayTickCommand};
 
@@ -59,7 +61,7 @@ impl NetworkedBytes for ReplayFile {
     where
         Self: Sized,
     {
-        let (bytes, player_guids) = BTreeMap::<String, u16>::from_bytes(bytes)?;
+        let (bytes, player_guids) = BTreeMap::<PlayerGuid, u16>::from_bytes(bytes)?;
         let (bytes, ticks_vec) = Vec::<ReplayTick>::from_bytes(bytes)?;
         let (bytes, level_name) = String::from_bytes(bytes)?;
         let (bytes, level_data) = String::from_bytes(bytes)?;

--- a/dogfight/src/replay/events.rs
+++ b/dogfight/src/replay/events.rs
@@ -28,7 +28,7 @@ pub enum ReplayEventType {
     //PlayerJoin(String),
     //PlayerLeave(String),
     //PlayerJoinTeam { id: PlayerId, team: Team },
-    //ChatMessage(ChatMessage),
+    ChatMessage(ChatMessage),
     Suicide,
     Killed(PlayerGuid),
     KilledBy(PlayerGuid),
@@ -50,13 +50,6 @@ pub(crate) fn output_to_events(world: &World, tick: u32, event: ServerOutput) ->
     let mut output: Vec<ReplayEvent> = vec![];
 
     match event {
-        //ServerOutput::PlayerJoin(p) => Some(ReplayEventType::PlayerJoin(p)),
-        //ServerOutput::PlayerLeave(p) => Some(ReplayEventType::PlayerLeave(p)),
-        /*
-        ServerOutput::PlayerJoinTeam { id, team } => {
-            Some(ReplayEventType::PlayerJoinTeam { id, team })
-        }
-        */
         ServerOutput::KillEvent(kill_event) => {
             // Mapping this to a different type with guids is easier
             // than refactoring the entire engine to support guids in KillEvent
@@ -113,10 +106,12 @@ pub(crate) fn output_to_events(world: &World, tick: u32, event: ServerOutput) ->
                 },
             };
         }
-        //ServerOutput::ChatMessage(chat_message) => Some(ReplayEventType::ChatMessage(chat_message)),
-        _ => {} // We don't care about the following when summarizing a game
-                //ServerOutput::YourPlayerGuid(_) => None,
-                //ServerOutput::EntityChanges(_) => None,
+        ServerOutput::ChatMessage(guid, chat_message) => output.push(ReplayEvent {
+            tick,
+            player: guid,
+            event: ReplayEventType::ChatMessage(chat_message),
+        }),
+        _ => {}
     };
 
     output

--- a/dogfight/src/replay/events.rs
+++ b/dogfight/src/replay/events.rs
@@ -1,11 +1,30 @@
+use serde::Serialize;
+use ts_rs::TS;
+use web_sys::js_sys::Math::max;
+
 use crate::{
+    debug::log,
     entities::{container::PlayerId, types::Team},
     game_event::{ChatMessage, KillEvent},
+    network::encoding::NetworkedBytes,
     output::ServerOutput,
+    world::World,
 };
 
+use super::file::ReplayFile;
+
+#[derive(Debug, Serialize, TS)]
+#[ts(export)]
+struct ReplayEvent {
+    pub tick: u32,
+    pub event: ReplayEventType,
+}
+
 // A subset of ServerOutput with only things we care about for replays
-pub enum ReplayEvent {
+#[derive(Debug, Serialize, TS)]
+#[ts(export)]
+#[serde(tag = "type", content = "data")]
+pub enum ReplayEventType {
     PlayerJoin(String),
     PlayerLeave(String),
     PlayerJoinTeam { id: PlayerId, team: Team },
@@ -13,14 +32,47 @@ pub enum ReplayEvent {
     ChatMessage(ChatMessage),
 }
 
-pub(crate) fn output_to_event(output: ServerOutput) -> Option<ReplayEvent> {
+pub(crate) fn output_to_event(output: ServerOutput) -> Option<ReplayEventType> {
     match output {
-        ServerOutput::PlayerJoin(p) => Some(ReplayEvent::PlayerJoin(p)),
-        ServerOutput::PlayerLeave(p) => Some(ReplayEvent::PlayerLeave(p)),
-        ServerOutput::PlayerJoinTeam { id, team } => Some(ReplayEvent::PlayerJoinTeam { id, team }),
-        ServerOutput::KillEvent(kill_event) => Some(ReplayEvent::KillEvent(kill_event)),
-        ServerOutput::ChatMessage(chat_message) => Some(ReplayEvent::ChatMessage(chat_message)),
+        ServerOutput::PlayerJoin(p) => Some(ReplayEventType::PlayerJoin(p)),
+        ServerOutput::PlayerLeave(p) => Some(ReplayEventType::PlayerLeave(p)),
+        ServerOutput::PlayerJoinTeam { id, team } => {
+            Some(ReplayEventType::PlayerJoinTeam { id, team })
+        }
+        ServerOutput::KillEvent(kill_event) => Some(ReplayEventType::KillEvent(kill_event)),
+        ServerOutput::ChatMessage(chat_message) => Some(ReplayEventType::ChatMessage(chat_message)),
+
+        // We don't care about the following when summarizing a game
         ServerOutput::YourPlayerGuid(_) => None,
         ServerOutput::EntityChanges(_) => None,
     }
+}
+
+pub fn get_replay_file_events(bytes: Vec<u8>) -> String {
+    match ReplayFile::from_bytes(&bytes) {
+        Some((_, replay_file)) => {
+            let events = parse_events(replay_file);
+            serde_json::to_string(&events).unwrap()
+        }
+        None => "".to_string(),
+    }
+}
+
+fn parse_events(replay_file: ReplayFile) -> Vec<ReplayEvent> {
+    let mut world = World::new();
+    world.load_level(&replay_file.level_data);
+
+    let mut events = vec![];
+
+    // Simulate the full game and collect events
+    let max_tick = replay_file
+        .ticks
+        .iter()
+        .map(|x| x.tick_number)
+        .max()
+        .unwrap();
+
+    log(format!("max tick: {}", max_tick));
+
+    events
 }

--- a/dogfight/src/replay/events.rs
+++ b/dogfight/src/replay/events.rs
@@ -15,7 +15,7 @@ use super::file::ReplayFile;
 
 #[derive(Debug, Serialize, TS)]
 #[ts(export)]
-struct ReplayEvent {
+pub struct ReplayEvent {
     pub tick: u32,
     pub event: ReplayEventType,
 }
@@ -32,8 +32,8 @@ pub enum ReplayEventType {
     ChatMessage(ChatMessage),
 }
 
-pub(crate) fn output_to_event(output: ServerOutput) -> Option<ReplayEventType> {
-    match output {
+pub(crate) fn output_to_event(tick: u32, output: ServerOutput) -> Option<ReplayEvent> {
+    let event = match output {
         ServerOutput::PlayerJoin(p) => Some(ReplayEventType::PlayerJoin(p)),
         ServerOutput::PlayerLeave(p) => Some(ReplayEventType::PlayerLeave(p)),
         ServerOutput::PlayerJoinTeam { id, team } => {
@@ -45,6 +45,11 @@ pub(crate) fn output_to_event(output: ServerOutput) -> Option<ReplayEventType> {
         // We don't care about the following when summarizing a game
         ServerOutput::YourPlayerGuid(_) => None,
         ServerOutput::EntityChanges(_) => None,
+    };
+
+    match event {
+        Some(e) => Some(ReplayEvent { tick, event: e }),
+        None => None,
     }
 }
 
@@ -61,18 +66,5 @@ pub fn get_replay_file_events(bytes: Vec<u8>) -> String {
 fn parse_events(replay_file: ReplayFile) -> Vec<ReplayEvent> {
     let mut world = World::new();
     world.load_level(&replay_file.level_data);
-
-    let mut events = vec![];
-
-    // Simulate the full game and collect events
-    let max_tick = replay_file
-        .ticks
-        .iter()
-        .map(|x| x.tick_number)
-        .max()
-        .unwrap();
-
-    log(format!("max tick: {}", max_tick));
-
-    events
+    world.simulate_until(&replay_file, None)
 }

--- a/dogfight/src/replay/events.rs
+++ b/dogfight/src/replay/events.rs
@@ -149,14 +149,14 @@ fn summarize_replay(replay_file: ReplayFile) -> ReplaySummary {
             .player_guids
             .iter()
             .by_ref()
-            .map(|(guid, p_idx)| {
+            .map(|(guid, hashmap_number)| {
                 let name = replay_file
                     .ticks
                     .iter()
                     .flat_map(|x| x.1)
                     .find_map(|x| {
                         if let PlayerCommand::AddPlayer(add_player_data) = &x.command {
-                            if x.player_guid_index == *p_idx {
+                            if x.player_guid_index == *hashmap_number {
                                 return Some(add_player_data.name.clone());
                             }
                         }

--- a/dogfight/src/replay/events.rs
+++ b/dogfight/src/replay/events.rs
@@ -1,9 +1,7 @@
 use serde::Serialize;
 use ts_rs::TS;
-use web_sys::js_sys::Math::max;
 
 use crate::{
-    debug::log,
     entities::{container::PlayerId, types::Team},
     game_event::{ChatMessage, KillEvent},
     network::encoding::NetworkedBytes,

--- a/dogfight/src/replay/events.rs
+++ b/dogfight/src/replay/events.rs
@@ -1,0 +1,26 @@
+use crate::{
+    entities::{container::PlayerId, types::Team},
+    game_event::{ChatMessage, KillEvent},
+    output::ServerOutput,
+};
+
+// A subset of ServerOutput with only things we care about for replays
+pub enum ReplayEvent {
+    PlayerJoin(String),
+    PlayerLeave(String),
+    PlayerJoinTeam { id: PlayerId, team: Team },
+    KillEvent(KillEvent),
+    ChatMessage(ChatMessage),
+}
+
+pub(crate) fn output_to_event(output: ServerOutput) -> Option<ReplayEvent> {
+    match output {
+        ServerOutput::PlayerJoin(p) => Some(ReplayEvent::PlayerJoin(p)),
+        ServerOutput::PlayerLeave(p) => Some(ReplayEvent::PlayerLeave(p)),
+        ServerOutput::PlayerJoinTeam { id, team } => Some(ReplayEvent::PlayerJoinTeam { id, team }),
+        ServerOutput::KillEvent(kill_event) => Some(ReplayEvent::KillEvent(kill_event)),
+        ServerOutput::ChatMessage(chat_message) => Some(ReplayEvent::ChatMessage(chat_message)),
+        ServerOutput::YourPlayerGuid(_) => None,
+        ServerOutput::EntityChanges(_) => None,
+    }
+}

--- a/dogfight/src/replay/events.rs
+++ b/dogfight/src/replay/events.rs
@@ -78,14 +78,14 @@ fn summarize_replay(replay_file: ReplayFile) -> ReplaySummary {
             .player_guids
             .iter()
             .by_ref()
-            .map(|(guid, _)| {
+            .map(|(guid, p_idx)| {
                 let name = replay_file
                     .ticks
                     .iter()
                     .flat_map(|x| x.1)
                     .find_map(|x| {
                         if let PlayerCommand::AddPlayer(add_player_data) = &x.command {
-                            if add_player_data.guid == *guid {
+                            if x.player_guid_index == *p_idx {
                                 return Some(add_player_data.name.clone());
                             }
                         }

--- a/dogfight/src/replay/events.rs
+++ b/dogfight/src/replay/events.rs
@@ -25,11 +25,10 @@ pub struct ReplayEvent {
 #[ts(export)]
 #[serde(tag = "type", content = "data")]
 pub enum ReplayEventType {
-    PlayerJoin(String),
-    PlayerLeave(String),
-    PlayerJoinTeam { id: PlayerId, team: Team },
-    ChatMessage(ChatMessage),
-
+    //PlayerJoin(String),
+    //PlayerLeave(String),
+    //PlayerJoinTeam { id: PlayerId, team: Team },
+    //ChatMessage(ChatMessage),
     Suicide,
     Killed(PlayerGuid),
     KilledBy(PlayerGuid),

--- a/dogfight/src/replay/events.rs
+++ b/dogfight/src/replay/events.rs
@@ -64,5 +64,6 @@ pub fn get_replay_file_events(bytes: Vec<u8>) -> String {
 fn parse_events(replay_file: ReplayFile) -> Vec<ReplayEvent> {
     let mut world = World::new();
     world.load_level(&replay_file.level_data);
-    world.simulate_until(&replay_file, None)
+    // simulates the entire game and returns all events
+    world.simulate_until(&replay_file, None, true)
 }

--- a/dogfight/src/replay/file.rs
+++ b/dogfight/src/replay/file.rs
@@ -10,7 +10,7 @@ use crate::{
     world::World,
 };
 
-use super::events::{output_to_event, ReplayEvent};
+use super::events::{output_to_events, ReplayEvent};
 
 #[derive(Serialize, Deserialize, Debug, Clone, TS)]
 #[ts(export)]
@@ -170,8 +170,7 @@ impl World {
                 let output = self.flush_changed_state();
                 let tick_events: Vec<ReplayEvent> = output
                     .iter()
-                    .map(|x| output_to_event(self, current_tick, x.clone()))
-                    .filter_map(|x| x)
+                    .flat_map(|x| output_to_events(self, current_tick, x.clone()))
                     .collect();
 
                 events.extend(tick_events);

--- a/dogfight/src/replay/file.rs
+++ b/dogfight/src/replay/file.rs
@@ -135,7 +135,7 @@ impl World {
                         let player_guid = replay
                             .player_guids
                             .iter()
-                            .find(|x| *x.1 == c.player_guid_index)
+                            .nth(c.player_guid_index as usize)
                             .unwrap()
                             .0
                             .clone();

--- a/dogfight/src/replay/file.rs
+++ b/dogfight/src/replay/file.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
 use crate::{
+    debug::log,
     entities::player::PlayerGuid,
     input::{PlayerCommand, ServerInput},
     network::encoding::NetworkedBytes,
@@ -150,10 +151,18 @@ impl World {
                         let player_guid = replay
                             .player_guids
                             .iter()
-                            .nth(c.player_guid_index as usize)
+                            .find(|x| *x.1 == c.player_guid_index)
+                            // Since the hashmap saves with ordered keys, we cannot use nth
+                            // but rather have to find the guid where the values are the same
+                            // this took forever to figure out.
+                            //.nth(c.player_guid_index as usize)
                             .unwrap()
                             .0
                             .clone();
+
+                        if let PlayerCommand::AddPlayer(p) = &c.command {
+                            log(format!("guid ADD replay input: {:?}", c));
+                        }
 
                         ServerInput {
                             player_guid,

--- a/dogfight/src/replay/file.rs
+++ b/dogfight/src/replay/file.rs
@@ -170,7 +170,7 @@ impl World {
                 let output = self.flush_changed_state();
                 let tick_events: Vec<ReplayEvent> = output
                     .iter()
-                    .map(|x| output_to_event(current_tick, x.clone()))
+                    .map(|x| output_to_event(self, current_tick, x.clone()))
                     .filter_map(|x| x)
                     .collect();
 

--- a/dogfight/src/replay/file.rs
+++ b/dogfight/src/replay/file.rs
@@ -10,7 +10,7 @@ use crate::{
     world::World,
 };
 
-use super::events::{output_to_event, ReplayEvent, ReplayEventType};
+use super::events::{output_to_event, ReplayEvent};
 
 #[derive(Serialize, Deserialize, Debug, Clone, TS)]
 #[ts(export)]

--- a/dogfight/src/replay/file.rs
+++ b/dogfight/src/replay/file.rs
@@ -9,7 +9,7 @@ use crate::{
     world::World,
 };
 
-use super::events::{output_to_event, ReplayEvent};
+use super::events::{output_to_event, ReplayEvent, ReplayEventType};
 
 #[derive(Serialize, Deserialize, Debug, Clone, TS)]
 #[ts(export)]
@@ -64,20 +64,7 @@ pub struct ReplaySummary {
     pub level_name: String,
     pub total_ticks: u32,
     pub player_guids: BTreeMap<String, u16>,
-}
-
-impl TryInto<ReplaySummary> for ReplayFile {
-    type Error = ();
-
-    fn try_into(self) -> Result<ReplaySummary, Self::Error> {
-        Ok(ReplaySummary {
-            build_version: self.build_version,
-            build_commit: self.build_commit,
-            level_name: self.level_name,
-            total_ticks: self.ticks.iter().map(|x| *x.0).max().unwrap(),
-            player_guids: self.player_guids,
-        })
-    }
+    pub events: Vec<ReplayEvent>,
 }
 
 pub fn get_build_version() -> String {

--- a/dogfight/src/replay/file.rs
+++ b/dogfight/src/replay/file.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
 use crate::{
+    entities::player::PlayerGuid,
     input::{PlayerCommand, ServerInput},
     network::encoding::NetworkedBytes,
     world::World,
@@ -51,7 +52,7 @@ pub struct ReplayFile {
     pub level_name: String,
     pub level_data: String,
 
-    pub player_guids: BTreeMap<String, u16>,
+    pub player_guids: BTreeMap<PlayerGuid, u16>,
 
     pub ticks: HashMap<u32, Vec<ReplayTickCommand>>,
 }
@@ -63,7 +64,7 @@ pub struct ReplaySummary {
     pub build_commit: String,
     pub level_name: String,
     pub total_ticks: u32,
-    pub player_guids: BTreeMap<String, u16>,
+    pub players: BTreeMap<PlayerGuid, String>,
     pub events: Vec<ReplayEvent>,
 }
 

--- a/dogfight/src/replay/file.rs
+++ b/dogfight/src/replay/file.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeMap, env};
+use std::{
+    collections::{BTreeMap, HashMap},
+    env,
+    hash::Hash,
+};
 
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
@@ -125,11 +129,19 @@ impl World {
             None => replay.ticks.iter().map(|t| t.tick_number).max().unwrap(),
         };
 
+        let mut inputs: HashMap<u32, &Vec<ReplayTickCommand>> = HashMap::new();
+
+        // use tick hashmap lookup
+        for entry in replay.ticks.iter() {
+            inputs.insert(entry.tick_number, &entry.commands);
+        }
+
+        // ~8-9 seconds to parse 60 minute replay without optimization
+
         for current_tick in start_tick..max_tick {
-            let maybe_input = replay.ticks.iter().find(|x| x.tick_number == current_tick);
+            let maybe_input = inputs.get(&current_tick);
             let input: Vec<ServerInput> = match maybe_input {
                 Some(tick_data) => tick_data
-                    .commands
                     .iter()
                     .map(|c| {
                         let player_guid = replay

--- a/dogfight/src/replay/file.rs
+++ b/dogfight/src/replay/file.rs
@@ -12,8 +12,8 @@ use crate::{
 #[derive(Serialize, Deserialize, Debug, TS)]
 #[ts(export)]
 pub struct ReplayTickCommand {
-    player_guid_index: u16,
-    command: PlayerCommand,
+    pub player_guid_index: u16,
+    pub command: PlayerCommand,
 }
 
 impl ReplayTickCommand {
@@ -28,8 +28,8 @@ impl ReplayTickCommand {
 #[derive(Serialize, Deserialize, Debug, TS)]
 #[ts(export)]
 pub struct ReplayTick {
-    tick_number: u32,
-    commands: Vec<ReplayTickCommand>,
+    pub tick_number: u32,
+    pub commands: Vec<ReplayTickCommand>,
 }
 
 impl ReplayTick {
@@ -73,95 +73,6 @@ impl ReplayFile {
             player_guids: BTreeMap::new(),
             ticks: vec![],
         }
-    }
-}
-
-impl NetworkedBytes for ReplayFile {
-    fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = vec![];
-
-        // look how pretty this is
-        bytes.extend(self.player_guids.to_bytes());
-        bytes.extend(self.ticks.to_bytes());
-        bytes.extend(self.level_name.to_bytes());
-        bytes.extend(self.level_data.to_bytes());
-        bytes.extend(self.build_version.to_bytes());
-        bytes.extend(self.build_commit.to_bytes());
-
-        bytes
-    }
-
-    fn from_bytes(bytes: &[u8]) -> Option<(&[u8], Self)>
-    where
-        Self: Sized,
-    {
-        let (bytes, player_guids) = BTreeMap::<String, u16>::from_bytes(bytes)?;
-        let (bytes, ticks) = Vec::<ReplayTick>::from_bytes(bytes)?;
-        let (bytes, level_name) = String::from_bytes(bytes)?;
-        let (bytes, level_data) = String::from_bytes(bytes)?;
-        let (bytes, build_version) = String::from_bytes(bytes)?;
-        let (bytes, build_commit) = String::from_bytes(bytes)?;
-
-        Some((
-            bytes,
-            Self {
-                build_version,
-                build_commit,
-                level_name,
-                level_data,
-                player_guids,
-                ticks,
-            },
-        ))
-    }
-}
-
-impl NetworkedBytes for ReplayTick {
-    fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = vec![];
-        bytes.extend(u32::to_bytes(&self.tick_number));
-        bytes.extend(Vec::<ReplayTickCommand>::to_bytes(&self.commands));
-        bytes
-    }
-
-    fn from_bytes(bytes: &[u8]) -> Option<(&[u8], Self)>
-    where
-        Self: Sized,
-    {
-        let (mut bytes, tick_number) = u32::from_bytes(bytes)?;
-        let (slice, commands) = Vec::<ReplayTickCommand>::from_bytes(bytes)?;
-        bytes = slice;
-        Some((
-            bytes,
-            Self {
-                tick_number,
-                commands,
-            },
-        ))
-    }
-}
-
-impl NetworkedBytes for ReplayTickCommand {
-    fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = vec![];
-        bytes.extend(self.player_guid_index.to_bytes());
-        bytes.extend(self.command.to_bytes());
-        bytes
-    }
-
-    fn from_bytes(bytes: &[u8]) -> Option<(&[u8], Self)>
-    where
-        Self: Sized,
-    {
-        let (bytes, player_guid_index) = u16::from_bytes(bytes)?;
-        let (bytes, command) = PlayerCommand::from_bytes(bytes)?;
-        Some((
-            bytes,
-            Self {
-                player_guid_index,
-                command,
-            },
-        ))
     }
 }
 

--- a/dogfight/src/replay/mod.rs
+++ b/dogfight/src/replay/mod.rs
@@ -1,0 +1,4 @@
+pub mod encoding;
+pub mod file;
+
+pub mod events;

--- a/dogfight/src/tick_collision.rs
+++ b/dogfight/src/tick_collision.rs
@@ -2,6 +2,7 @@ use std::f64::consts::PI;
 
 use crate::{
     collision::SolidEntity,
+    debug::log,
     entities::{
         container::PlayerId,
         man::ManState,
@@ -91,7 +92,7 @@ impl World {
                             )));
                         }
                     }
-                    // web_sys::console::log_1(&format!("man collide runway!").into());
+                    // log(&format!("man collide runway!").into());
                     continue 'men;
                 }
             }
@@ -145,7 +146,7 @@ impl World {
                         _ => {}
                     };
 
-                    //web_sys::console::log_1(&format!("man collide ground!").into());
+                    //log(&format!("man collide ground!").into());
                     continue 'men;
                 }
             }
@@ -163,7 +164,7 @@ impl World {
                     }
                     // just kill me
                     actions.push(Action::RemoveEntity(RemoveData::Man(*man_id)));
-                    //web_sys::console::log_1(&format!("man collide coast!").into());
+                    //log(&format!("man collide coast!").into());
                     continue 'men;
                 }
             }
@@ -330,7 +331,7 @@ impl World {
                         bomb.get_x(),
                         bomb.get_y(),
                     );
-                    //web_sys::console::log_1(&format!("bomb collide ground!").into());
+                    //log(&format!("bomb collide ground!").into());
                     continue 'bombs;
                 }
             }
@@ -344,7 +345,7 @@ impl World {
                         bomb.get_x(),
                         bomb.get_y(),
                     );
-                    //web_sys::console::log_1(&format!("bomb collide coast!").into());
+                    //log(&format!("bomb collide coast!").into());
                     continue 'bombs;
                 }
             }
@@ -352,7 +353,7 @@ impl World {
             for (_, water) in self.waters.get_map_mut() {
                 if bomb.check_collision(water) {
                     actions.push(Action::RemoveEntity(RemoveData::Bomb(*bomb_id)));
-                    //web_sys::console::log_1(&format!("bomb collide water!").into());
+                    //log(&format!("bomb collide water!").into());
                     continue 'bombs;
                 }
             }
@@ -679,7 +680,7 @@ impl World {
                             plane.set_angle(0.0);
                         }
 
-                        web_sys::console::log_1(&format!("plane can land on runway").into());
+                        log(format!("plane can land on runway").into());
                         plane.set_client_y(runway.get_landable_y() - plane.get_bottom_height());
 
                         // We want to do the team check before is_facing_runway
@@ -688,9 +689,7 @@ impl World {
                         if plane.get_team() == *runway.get_team()
                             && plane.is_facing_runway_correctly(runway)
                         {
-                            web_sys::console::log_1(
-                                &format!("plane facing runway correctly").into(),
-                            );
+                            log(format!("plane facing runway correctly").into());
                             plane.set_mode(PlaneMode::Landing);
                             plane.set_runway(Some(*runway_id));
                         }

--- a/dogfight/src/world.rs
+++ b/dogfight/src/world.rs
@@ -95,7 +95,7 @@ impl World {
     }
     */
 
-    pub(crate) fn get_tick(&self) -> u32 {
+    pub fn get_tick(&self) -> u32 {
         self.game_tick
     }
 

--- a/dogfight/src/world.rs
+++ b/dogfight/src/world.rs
@@ -130,7 +130,7 @@ impl World {
         let updated_state = self.get_changed_state();
 
         if updated_state.len() > 0 {
-            // web_sys::console::log_1(&format!("{:?}", updated_state).into());
+            // log(&format!("{:?}", updated_state).into());
             self.game_output
                 .push(ServerOutput::EntityChanges(updated_state));
         }

--- a/dogfight/src/world.rs
+++ b/dogfight/src/world.rs
@@ -14,7 +14,7 @@ use crate::{
         hill::Hill,
         man::Man,
         plane::Plane,
-        player::Player,
+        player::{Player, PlayerGuid},
         runway::Runway,
         types::EntityType,
         water::Water,
@@ -158,7 +158,7 @@ impl World {
             .find(|(_, p)| p.get_name().eq(name))
     }
 
-    pub(crate) fn get_player_from_guid(&self, guid: &String) -> Option<(&PlayerId, &Player)> {
+    pub(crate) fn get_player_from_guid(&self, guid: &PlayerGuid) -> Option<(&PlayerId, &Player)> {
         self.players
             .get_map()
             .iter()
@@ -167,7 +167,7 @@ impl World {
 
     pub(crate) fn get_player_from_guid_mut(
         &mut self,
-        guid: &String,
+        guid: &PlayerGuid,
     ) -> Option<(&PlayerId, &mut Player)> {
         self.players
             .get_map_mut()

--- a/dogfight/src/world.rs
+++ b/dogfight/src/world.rs
@@ -15,14 +15,14 @@ use crate::{
         man::Man,
         plane::Plane,
         player::Player,
-        runway::{self, Runway},
+        runway::Runway,
         types::EntityType,
         water::Water,
         world_info::WorldInfo,
     },
     input::ServerInput,
     output::ServerOutput,
-    replay::ReplayFile,
+    replay::file::ReplayFile,
 };
 
 pub const DIRECTIONS: i32 = 256;


### PR DESCRIPTION
relates to #29 

A rough prototype, but added the foundations for the most important features. There are still some minor issues with it at the moment. For example, some player's team assignments and team colors are rendering incorrectly (as seen in screenshot with Fokker), and sometimes abandoned parachuters/planes are shown in replays which (most likely) weren't there in the original game, so still have to figure out what is causing that and why.


* Adds a time progress bar to know how far along in the replay you are
* Allows scrubbing progress bar to jump to different times
* Allows pausing/playing the replay
* Allows advancing by one frame if paused
* Allows going forward/backward 5 and 30 seconds
* Allows spectating players
* Allows the user to view certain events (kills, killed by, chat, etc). and allows the user to jump to 5 seconds before that event happened
* Fixes gameLoop issues with starting/stopping game loop
* Adds ability to pause gameLoop
* Adds `PlayerGuid` type in game engine to better represent payer guids instead of `String`
* Organize replay related rust code into its own module

<img width="1246" alt="image" src="https://github.com/user-attachments/assets/438b17ae-4388-48e7-898d-2912bf165333" />

